### PR TITLE
Prepare SCP Additions 3.0 release notes and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,105 @@
 # Changelog
 
+## SCP Additions 3.0.0 — Mega SCP Unity Update
+
+The largest SCP Additions update so far. SCP Inventory and SCP Unity Extra Blocks have been consolidated into SCP Additions as internal systems, so only one mod file is required.
+
+### Integrated SCP Inventory systems
+
+- Added the full SCP Inventory interface with dedicated storage for general items, equipment, keycards, ammunition, weapons, documents, and currency;
+- Added configurable item classification and pickup routing, including custom-only keycard and currency storage;
+- Added equipment slots, shift-click equipment handling, context menus, item actions, dropping, moving, and usable-item sessions;
+- Added Codex and Status panels with configurable document entries and item information;
+- Added custom pickup prompts, inventory-full feedback, contextual interaction prompts, and configurable interaction icons;
+- Added localized Roboto font rendering throughout the SCP Inventory and interaction interfaces without replacing Minecraft's global font;
+- Added server-authoritative inventory synchronization, persistence, death handling, logout handling, and duplication safeguards;
+- Added compatibility access services so keycard readers, Tesla terminals, and other systems can detect items stored in the custom inventory;
+- Added configurable custom health and stamina HUDs;
+- Added horror-style movement behavior, sprint stamina consumption, regeneration delay, exhausted sprint lock, and configurable stamina-blocking items;
+- Added configurable modules for inventory, HUD, custom health, stamina, horror movement, blink, and SCP-173 behavior;
+
+### Blink and visual systems
+
+- Added automatic blinking with configurable timing;
+- Added a manual hold-to-blink keybind;
+- Added blink meter, vignette, blackout, and post-blink screen effects;
+- Added synchronized server-side eye state used by SCP-173 and other observers;
+- Added the Eye Sore effect, which accelerates blink drain;
+- Added SCP-173 threat confirmation, reveal feedback, and temporary paranoia retention;
+
+### SCP-173
+
+- Added a fully functional SCP-173 entity with GeckoLib model and animation support;
+- Added observation checks for players, configured mobs, raiders, and SCP-131;
+- Added sampled line-of-sight checks that correctly handle transparent and solid blocks;
+- Added deterministic snap movement, direct pursuit, path fallback, and side-step fallback behavior;
+- Added immediate movement reevaluation when observers blink or close their eyes;
+- Added contact-only neck snap damage and a dedicated death message;
+- Added configurable natural spawning, isolated routine-spawn behavior, inactivity until first observation, and unseen despawning;
+- Added target recovery after player respawn and isolated post-kill despawning;
+- Added frozen air and water behavior while observed;
+- Added movement scrape, rattle, scare, horror, death, and neck-snap sounds;
+- Added 1730 health, strong armor, toughness, knockback resistance, and custom durability rules;
+
+### SCP-131-A and SCP-131-B
+
+- Added SCP-131-A and SCP-131-B as spawnable entities;
+- Added GeckoLib models, animations, translucent rendering, and glowing eye layers;
+- Added idle voice sounds and custom SCP-styled interaction notices;
+- Added right-click following behavior;
+- Added a physical G-key hold action to stop owned SCP-131 followers;
+- Added persistent following ownership across save and reload;
+- Added SCP-131-B following nearby idle SCP-131-A entities;
+- Added SCP-131 observation behavior against SCP-173;
+
+### SCP Unity facility content
+
+- Integrated the SCP Unity Extra Blocks architectural set into SCP Additions;
+- Added Tesla, Archival, Office, Skyroom, and Security structural blocks;
+- Added Alarm Lamps, Wall Lights, Heaters, Sign Supports, TVs, Trashbins, and other facility props;
+- Added animated Default, Yellow, Black, Normal, Logistics, Office, Bathroom, and Workshop door families;
+- Added family-specific opening and closing animations, timing, sounds, drops, collision behavior, and direct or redstone activation rules;
+- Added a unified SCP Unity Blocks creative tab with a curated block order;
+- Added functional door buttons with mirrored left and right models;
+- Updated paired button behavior so an existing opposite panel synchronizes without automatically creating a second panel behind the wall;
+- Fixed left button selection geometry and multiple door/button synchronization issues;
+- Added legacy mapping from SCP Unity Extra Blocks registry IDs to their SCP Additions equivalents;
+- Preserved intermediate door animation states for saved-world compatibility while hiding them from the creative tab;
+- Added Sector 1 and Sector 2 floors, walls, directional floor arrows, wall details, and an open ventilation model from the SCP UBlocks assets;
+- Added legacy mapping from `scp_ublocks` block and item IDs to their SCP Additions equivalents;
+
+### Keycards, readers, and tools
+
+- Integrated keycards with the custom inventory without maintaining duplicate vanilla mirror stacks;
+- Fixed survival keycard jitter caused by repeated mirror synchronization;
+- Updated shared inventory checks so readers detect custom-only keycards directly;
+- Added a screwdriver texture and item model;
+- Added crouch-and-screwdriver reader configuration through both direct interaction and the custom contextual interaction system;
+- Preserved six keycard clearance levels and higher-level access to lower-level readers;
+
+### Configuration and data
+
+- Added `config/scpadditions/modules.json` for gameplay module controls;
+- Added `config/scpinventory/scpinventory.json` for inventory, HUD, stamina, movement, blink, and item behavior;
+- Added `config/scpinventory/context_interactions.json` for contextual block and entity interactions;
+- Added expanded default SCP-294 drink definitions;
+- Added expanded default SCP-914 item and entity recipes;
+- Added first-run copying of bundled default configuration files;
+- Existing local configuration files are not overwritten automatically;
+- Kept SCP-294 currency handling exclusive to either the custom inventory or vanilla inventory, depending on the selected inventory mode;
+
+### Compatibility and technical changes
+
+- SCP Additions is now the only Forge mod entrypoint and the only required SCP Additions project JAR;
+- SCP Inventory and SCP Unity Extra Blocks are included internally and must not be installed separately;
+- Updated the mod version to 3.0.0;
+- Added GeckoLib 4.4.9 or newer as a required dependency;
+- Updated the minimum Forge version to 47.4.10;
+- Preserved existing published SCP Additions registry IDs for old-world compatibility;
+- Added compatibility mappings for migrated facility content;
+- Added extensive configuration defaults, migration documentation, and build validation;
+- Fixed multiple item duplication, pickup routing, keycard synchronization, usable-session, interface, rendering, button, door, font, and configuration-generation issues.
+
 ## SCP Additions 2.0.2
 
 Hotfix update for the 2.0.1 hotfix.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,91 @@
 # SCP Additions
 
-SCP Additions is a Forge mod for Minecraft 1.20.1 that expands SCP-themed gameplay with containment tools, security systems, interactive SCP objects, and Foundation-inspired machinery.
+SCP Additions is a Forge mod for Minecraft 1.20.1 that expands SCP-themed gameplay with containment machinery, facility security systems, anomalous objects, custom survival mechanics, and SCP Unity-inspired construction content.
 
-The project continues the spirit of classic SCP security and containment mods while adding new mechanics such as Tesla Gates, keycards, SCP-294, SCP-914, SCP-079, SCP-330, SCP-426, SCP-572, SCP-902, SCP-1176, decontamination checkpoints, and other SCP-related features.
+Version 3.0 consolidates the former SCP Inventory and SCP Unity Extra Blocks projects directly into SCP Additions. Only the SCP Additions JAR is required; the two standalone project JARs should not be installed alongside it.
 
-## Features
+## Requirements
 
-- **Tesla Gates**: electrified gates for containment areas and secure facilities, with global terminal control and emergency override behavior.
-- **Tesla Gate Terminals**: SCP Unity-inspired terminal interface with Security Credentials, global Tesla Gate controls, manual override, custom sounds, and updated terminal models.
-- **Keycards and Readers**: six clearance levels, with higher-level keycards opening their own level and lower-level readers.
-- **Decontamination Checkpoint**: removes active effects and can optionally act as a checkpoint through gamerules.
-- **SCP-079**: an interactive system-control SCP that can affect facility systems.
-- **SCP-294**: a configurable drink machine with dynamic cups, custom drinks, effects, sounds, actions, and data-driven drink definitions.
-- **SCP-914**: a configurable refinement machine with item and entity recipes, weighted outputs, draggable dial GUI, and an assembly kit for placing the full machine structure.
-- **Additional SCP objects**: SCP-330, SCP-426, SCP-572, SCP-902, SCP-1176, and related items.
+- Minecraft 1.20.1
+- Forge 47.4.10 or newer
+- GeckoLib 4.4.9 or newer
+- `kleiders_custom_renderer` is optional
+
+## Major features
+
+### SCP Inventory and survival systems
+
+- Custom SCP-styled inventory with dedicated general, equipment, keycard, ammunition, weapon, document, and currency storage.
+- Configurable item classification, pickup routing, context menus, item actions, equipment handling, and usable-item sessions.
+- Codex and Status panels.
+- Custom pickup prompts, interaction prompts, inventory-full feedback, and localized Roboto interface rendering.
+- Custom health and stamina HUDs.
+- Horror-style movement, sprint stamina, regeneration delay, exhausted sprint lock, and configurable stamina-blocking items.
+- Server-authoritative synchronization, persistence, death handling, and duplication safeguards.
+
+### Blink system and SCP entities
+
+- Automatic and manual hold-to-blink behavior with synchronized eye state.
+- Blink meter, vignette, blackout, post-blink cover, and Eye Sore drain acceleration.
+- SCP-173 with GeckoLib rendering, observation checks, deterministic snap movement, path fallback, neck-snap damage, configurable natural spawning, durability rules, and a complete sound set.
+- SCP-131-A and SCP-131-B with animated models, glowing eyes, following behavior, persistent ownership, custom notices, and SCP-173 observation behavior.
+
+### Facility systems
+
+- Tesla Gates with global terminal controls and Emergency Override behavior.
+- SCP Unity-inspired Tesla Gate Terminal interface with Security Credentials and custom sounds.
+- Six keycard clearance levels and configurable keycard readers.
+- Screwdriver-based reader configuration through direct or contextual interaction.
+- Decontamination Checkpoints.
+- SCP-079 facility controls.
+- SCP Unity-inspired architectural blocks, lights, props, doors, buttons, and facility sounds.
+- Animated Default, Yellow, Black, Normal, Logistics, Office, Bathroom, and Workshop doors.
+- Sector 1 and Sector 2 floors, walls, directional arrows, wall details, and ventilation pieces.
+
+### SCP machinery and anomalous objects
+
+- **SCP-294**: configurable drink machine with dynamic cups, fuzzy matching, aliases, effects, actions, sounds, custom death messages, and data-driven drink definitions.
+- **SCP-914**: configurable refinement machine with item and entity recipes, weighted outputs, recipe fragments, draggable dial GUI, machine offsets, and an assembly kit for placing the complete structure.
+- **Additional SCP content**: SCP-330, SCP-426, SCP-572, SCP-902, SCP-1176, and related items and mechanics.
 
 ## Configuration
 
-Some systems are data/config-driven and can be expanded without rebuilding the mod:
+Major systems are configurable without rebuilding the mod:
 
+- `config/scpadditions/modules.json`
 - `config/scpadditions/294drinks.json`
 - `config/scpadditions/914recipes.json`
 - `config/scpadditions/914recipes.d/*.json`
+- `config/scpinventory/scpinventory.json`
+- `config/scpinventory/context_interactions.json`
 
-If you update from an older version and want the newest default configs, delete the old generated config files and let the mod regenerate them.
+Bundled defaults are copied only when a configuration file does not already exist. Existing local configurations are not overwritten automatically.
 
-## License and SCP Attribution
+To regenerate the newest defaults, back up and remove the relevant generated configuration files before starting the game again.
 
-Content relating to the SCP Foundation, including SCP concepts, is licensed under Creative Commons ShareAlike 3.0 and originates from the SCP Wiki and its authors.
+## Compatibility
 
-SCP Additions is also released under Creative Commons ShareAlike 3.0.
+- Existing published SCP Additions registry IDs are preserved for older worlds.
+- Migrated SCP Unity Extra Blocks and SCP UBlocks IDs are remapped to their SCP Additions equivalents when possible.
+- Intermediate animated door states remain registered for saved-world compatibility but are hidden from the creative inventory.
+- SCP Inventory and facility resource namespaces remain bundled internally where required by models, textures, animations, fonts, and sounds.
+
+Always back up important worlds before updating between major versions.
+
+## Building from source
+
+The project uses Java 17 and the included Gradle wrapper:
+
+```bash
+./gradlew clean build
+```
+
+The compiled JAR is generated under `build/libs`.
+
+## License and SCP attribution
+
+Content relating to the SCP Foundation, including SCP concepts, is licensed under Creative Commons Attribution-ShareAlike 3.0 and originates from the SCP Wiki and its authors.
+
+SCP Additions is also released under Creative Commons Attribution-ShareAlike 3.0.
 
 This is not an official Minecraft product and is not affiliated with Mojang, Microsoft, or the SCP Wiki staff.


### PR DESCRIPTION
Adds the complete SCP Additions 3.0.0 changelog in the established 2.x style and rewrites the README for the consolidated SCP Inventory, SCP-173/131, blink/vitals, facility content, requirements, configuration, and compatibility model.