### PR TITLE
Fix SCP-914 language and death sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The largest SCP Additions update so far. SCP Inventory and SCP Unity Extra Block
 - Kept Kleiders Custom Renderer optional: it is required only to render SCP-914-selected player skins;
 - Added MoreMcmeta Emissive Textures as an optional client dependency for supported emissive facility textures;
 - Clarified that GeckoLib 4.4.9 or newer is required while Kleiders Custom Renderer and MoreMcmeta Emissive Textures are optional client enhancements;
+- Added the missing SCP-914 Coarse death message and Metamorphosis advancement title translations;
+- Restored the SCP-914 death sound when a setting-specific player outcome actually kills the player;
 
 ### Integrated SCP Inventory systems
 

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914Processor.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914Processor.java
@@ -34,6 +34,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 import net.mcreator.scpadditions.ScpAdditionsMod;
 import net.mcreator.scpadditions.init.ScpAdditionsModBlocks;
+import net.mcreator.scpadditions.init.ScpAdditionsModSounds;
 import net.mcreator.scpadditions.network.ScpAdditionsModVariables;
 
 import java.util.Comparator;
@@ -195,7 +196,13 @@ public final class Scp914Processor {
                         entity.getDisplayName());
             }
         };
-        player.hurt(source, amount);
+        boolean wasAlive = player.isAlive();
+        boolean damaged = player.hurt(source, amount);
+        if (damaged && wasAlive && player.isDeadOrDying()) {
+            player.level().playSound(null, player.blockPosition(),
+                    ScpAdditionsModSounds.SCP914DEATH.get(),
+                    SoundSource.NEUTRAL, 1.0F, 1.0F);
+        }
     }
 
     private static void awardMetamorphosisAdvancement(ServerPlayer player) {

--- a/src/main/resources/assets/scp_additions/lang/en_us.json
+++ b/src/main/resources/assets/scp_additions/lang/en_us.json
@@ -258,5 +258,7 @@
   "block.scp_additions.lv_4_right_reader_wrong": "Level 4 Keycard Reader (Right) Denied",
   "item.scp_additions.level_6_keycard": "Level 6 Keycard",
   "subtitles.stomach": "Stomach ache",
-  "item.scp_additions.carbon": "Cup of Carbon"
+  "item.scp_additions.carbon": "Cup of Carbon",
+  "death.attack.scp914coarse": "%s died from internal injuries after being \"refined\" by SCP-914 on the \"Coarse\" setting.",
+  "advancements.scp_914_metamorphosis.title": "Metamorphosis"
 }


### PR DESCRIPTION
The clean fix commit passed resource validation and a full Gradle build, then was promoted directly to master. It adds the missing language entries and plays the registered SCP-914 death sound only after an SCP-914 damage event actually kills the player.