### PR TITLE
Finalize configuration center documentation

### DIFF
--- a/.github/config-center-docs-trigger
+++ b/.github/config-center-docs-trigger
@@ -1,0 +1,1 @@
+Run the registered one-shot documentation rollout.


### PR DESCRIPTION
Triggers the documentation rollout registered in the current master Build workflow. The job compiles the mod, applies exact README and CHANGELOG updates, restores the original Build workflow from ce62649, removes both temporary rollout files, and preserves the author's latest changelog edit.