### PR TITLE
Draft: SCP-914 generic recipe fallback

### DIFF
--- a/docs/SCP914_GENERIC_RECIPES.md
+++ b/docs/SCP914_GENERIC_RECIPES.md
@@ -1,0 +1,44 @@
+# Generic SCP-914 recipe fallback
+
+This branch adds an optional behavior layer derived from the crafting recipes loaded by the server. It does not replace or reinterpret any recipe in `914recipes.json` or `914recipes.d`.
+
+## Priority
+
+1. Explicit SCP-914 JSON recipe for the selected setting;
+2. generic recipe fallback;
+3. no item transformation.
+
+If a non-player entity is present in the intake and no explicit recipe matches it, generic item processing is not attempted. This prevents a crafting fallback from silently ignoring an entity.
+
+## Setting behavior
+
+### Rough
+
+A single crafted item can be broken back into one randomly selected ingredient. There is also a chance that nothing recoverable survives. Only recipes that produce exactly one result are reversible, which prevents common compression and quantity exploits.
+
+### Coarse
+
+A single crafted item can be disassembled into a random incomplete subset of its recipe ingredients. At least one component survives when a reversible recipe exists, but full recovery is not guaranteed.
+
+### 1:1
+
+When the exact intake can form several different crafting results, one is selected randomly. A single item can also be replaced by another craftable item in the same narrow equipment or tool family. Broad generic `Item` and arbitrary block substitutions are deliberately excluded.
+
+### Fine
+
+The intake is treated as an unordered set of crafting ingredients. Shaped and shapeless recipes are both accepted, and multiple compatible recipes are resolved randomly. Every intake item must be used; extra items prevent the generic match. Crafting remainders such as buckets are returned.
+
+### Very Fine
+
+The machine first resolves the same exact crafting result as Fine. It then attempts one additional recipe step only when the entire second recipe can be made from the quantity of that intermediate result. This allows transformations such as a recipe output immediately becoming a more elaborate form without inventing unrelated missing ingredients.
+
+## Safeguards
+
+- Special and dynamic crafting recipes are excluded initially.
+- Forward crafting is limited to the normal nine ingredient capacity.
+- Reverse processing accepts only recipes with one output item and never returns the original input as a component.
+- Explicit SCP-914 configuration always wins.
+- Ambiguous valid results use the server random source rather than a fixed recipe order.
+- Item and entity inputs are never mixed by the generic fallback.
+
+The behavior is intentionally not a guaranteed upgrade path. SCP-914 documentation and experiment logs consistently portray the machine as setting-dependent, unpredictable and capable of literal, indirect or destructive interpretations.

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914GenericRecipeResolver.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914GenericRecipeResolver.java
@@ -1,0 +1,371 @@
+package net.mcreator.scpadditions.data;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.DiggerItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ProjectileWeaponItem;
+import net.minecraft.world.item.SwordItem;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Conservative fallback that derives SCP-914 transformations from the crafting
+ * recipes currently loaded by the server. Explicit SCP-914 JSON recipes always
+ * take priority and never pass through this resolver.
+ */
+public final class Scp914GenericRecipeResolver {
+    private static final int MAX_FORWARD_INGREDIENTS = 9;
+
+    private Scp914GenericRecipeResolver() {
+    }
+
+    public static Optional<GenericMatch> find(ServerLevel level,
+                                              Scp914RecipeManager.Setting setting,
+                                              List<ItemEntity> itemEntities) {
+        if (level == null || itemEntities == null || itemEntities.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return switch (setting) {
+            case ROUGH -> findReverse(level, itemEntities, true);
+            case COARSE -> findReverse(level, itemEntities, false);
+            case ONE_TO_ONE -> findOneToOne(level, itemEntities);
+            case FINE -> findForward(level, itemEntities, false);
+            case VERY_FINE -> findForward(level, itemEntities, true);
+        };
+    }
+
+    private static Optional<GenericMatch> findForward(ServerLevel level,
+                                                       List<ItemEntity> entities,
+                                                       boolean veryFine) {
+        List<ItemUnit> units = expandUnits(entities, MAX_FORWARD_INGREDIENTS);
+        if (units.isEmpty()) return Optional.empty();
+
+        List<ForwardCandidate> candidates = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            List<Ingredient> ingredients = nonEmptyIngredients(recipe);
+            if (ingredients.size() != units.size()) continue;
+            Optional<List<ItemUnit>> assignment = assignIngredients(ingredients, units);
+            if (assignment.isEmpty()) continue;
+
+            ItemStack result = result(level, recipe);
+            if (result.isEmpty()) continue;
+            candidates.add(new ForwardCandidate(recipe.getId(), assignment.get(), result));
+        }
+        if (candidates.isEmpty()) return Optional.empty();
+
+        ForwardCandidate selected = random(candidates, level.random);
+        ItemStack output = selected.result().copy();
+        ResourceLocation resolvedRecipe = selected.recipeId();
+        if (veryFine) {
+            Optional<RecipeResult> successor = findHomogeneousSuccessor(level, output);
+            if (successor.isPresent()) {
+                output = successor.get().stack();
+                resolvedRecipe = successor.get().recipeId();
+            }
+        }
+
+        List<ItemStack> outputs = new ArrayList<>();
+        outputs.add(output);
+        outputs.addAll(craftingRemainders(selected.assignment()));
+        return Optional.of(new GenericMatch(
+                settingName(veryFine ? Scp914RecipeManager.Setting.VERY_FINE : Scp914RecipeManager.Setting.FINE),
+                resolvedRecipe,
+                collapseUses(selected.assignment()),
+                combineStacks(outputs)));
+    }
+
+    private static Optional<GenericMatch> findReverse(ServerLevel level,
+                                                       List<ItemEntity> entities,
+                                                       boolean rough) {
+        List<ItemUnit> units = expandUnits(entities, 2);
+        if (units.size() != 1) return Optional.empty();
+        ItemUnit input = units.get(0);
+
+        List<ReverseCandidate> candidates = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            ItemStack result = result(level, recipe);
+            if (result.isEmpty() || result.getCount() != 1
+                    || !ItemStack.isSameItem(result, input.stack())) continue;
+
+            List<ItemStack> recovered = new ArrayList<>();
+            for (Ingredient ingredient : nonEmptyIngredients(recipe)) {
+                ItemStack concrete = chooseIngredientStack(ingredient, level.random);
+                if (!concrete.isEmpty() && !ItemStack.isSameItem(concrete, input.stack())) {
+                    recovered.add(concrete);
+                }
+            }
+            if (!recovered.isEmpty()) candidates.add(new ReverseCandidate(recipe.getId(), recovered));
+        }
+        if (candidates.isEmpty()) return Optional.empty();
+
+        ReverseCandidate selected = random(candidates, level.random);
+        List<ItemStack> recovered = rough
+                ? roughRecovery(selected.ingredients(), level.random)
+                : coarseRecovery(selected.ingredients(), level.random);
+        return Optional.of(new GenericMatch(
+                settingName(rough ? Scp914RecipeManager.Setting.ROUGH : Scp914RecipeManager.Setting.COARSE),
+                selected.recipeId(),
+                List.of(new Scp914RecipeManager.ItemUse(input.entity(), 1)),
+                combineStacks(recovered)));
+    }
+
+    private static Optional<GenericMatch> findOneToOne(ServerLevel level,
+                                                        List<ItemEntity> entities) {
+        List<ItemUnit> units = expandUnits(entities, MAX_FORWARD_INGREDIENTS);
+        if (units.isEmpty()) return Optional.empty();
+
+        List<ForwardCandidate> direct = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            List<Ingredient> ingredients = nonEmptyIngredients(recipe);
+            if (ingredients.size() != units.size()) continue;
+            Optional<List<ItemUnit>> assignment = assignIngredients(ingredients, units);
+            if (assignment.isEmpty()) continue;
+            ItemStack result = result(level, recipe);
+            if (!result.isEmpty()) direct.add(new ForwardCandidate(recipe.getId(), assignment.get(), result));
+        }
+
+        if (direct.size() > 1) {
+            ForwardCandidate selected = random(direct, level.random);
+            List<ItemStack> outputs = new ArrayList<>();
+            outputs.add(selected.result().copy());
+            outputs.addAll(craftingRemainders(selected.assignment()));
+            return Optional.of(new GenericMatch(settingName(Scp914RecipeManager.Setting.ONE_TO_ONE),
+                    selected.recipeId(), collapseUses(selected.assignment()), combineStacks(outputs)));
+        }
+
+        if (units.size() != 1) return Optional.empty();
+        ItemUnit input = units.get(0);
+        List<RecipeResult> equivalents = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            ItemStack output = result(level, recipe);
+            if (output.isEmpty() || output.getCount() != 1
+                    || ItemStack.isSameItem(output, input.stack())) continue;
+            if (isEquivalentCategory(input.stack().getItem(), output.getItem())) {
+                equivalents.add(new RecipeResult(recipe.getId(), output));
+            }
+        }
+        if (equivalents.isEmpty()) return Optional.empty();
+
+        RecipeResult selected = random(equivalents, level.random);
+        return Optional.of(new GenericMatch(settingName(Scp914RecipeManager.Setting.ONE_TO_ONE),
+                selected.recipeId(), List.of(new Scp914RecipeManager.ItemUse(input.entity(), 1)),
+                List.of(selected.stack().copy())));
+    }
+
+    private static Optional<RecipeResult> findHomogeneousSuccessor(ServerLevel level, ItemStack intermediate) {
+        if (intermediate.isEmpty()) return Optional.empty();
+        ItemStack one = intermediate.copy();
+        one.setCount(1);
+
+        List<RecipeResult> successors = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            List<Ingredient> ingredients = nonEmptyIngredients(recipe);
+            if (ingredients.isEmpty() || ingredients.size() > intermediate.getCount()) continue;
+            boolean allMatch = true;
+            for (Ingredient ingredient : ingredients) {
+                if (!ingredient.test(one)) {
+                    allMatch = false;
+                    break;
+                }
+            }
+            if (!allMatch) continue;
+            ItemStack result = result(level, recipe);
+            if (result.isEmpty() || ItemStack.isSameItem(result, intermediate)) continue;
+            successors.add(new RecipeResult(recipe.getId(), result));
+        }
+        return successors.isEmpty() ? Optional.empty() : Optional.of(random(successors, level.random));
+    }
+
+    private static Optional<List<ItemUnit>> assignIngredients(List<Ingredient> ingredients,
+                                                               List<ItemUnit> units) {
+        boolean[] used = new boolean[units.size()];
+        List<ItemUnit> assignment = new ArrayList<>();
+        return assignRecursive(ingredients, units, 0, used, assignment)
+                ? Optional.of(List.copyOf(assignment)) : Optional.empty();
+    }
+
+    private static boolean assignRecursive(List<Ingredient> ingredients, List<ItemUnit> units,
+                                           int ingredientIndex, boolean[] used,
+                                           List<ItemUnit> assignment) {
+        if (ingredientIndex >= ingredients.size()) return true;
+        Ingredient ingredient = ingredients.get(ingredientIndex);
+        for (int i = 0; i < units.size(); i++) {
+            if (used[i] || !ingredient.test(units.get(i).stack())) continue;
+            used[i] = true;
+            assignment.add(units.get(i));
+            if (assignRecursive(ingredients, units, ingredientIndex + 1, used, assignment)) return true;
+            assignment.remove(assignment.size() - 1);
+            used[i] = false;
+        }
+        return false;
+    }
+
+    private static List<ItemUnit> expandUnits(List<ItemEntity> entities, int maximum) {
+        int total = 0;
+        for (ItemEntity entity : entities) {
+            if (entity == null || entity.isRemoved() || entity.getItem().isEmpty()) continue;
+            total += entity.getItem().getCount();
+            if (total > maximum) return List.of();
+        }
+        if (total <= 0) return List.of();
+
+        List<ItemUnit> units = new ArrayList<>(total);
+        for (ItemEntity entity : entities) {
+            ItemStack stack = entity.getItem();
+            if (stack.isEmpty()) continue;
+            for (int i = 0; i < stack.getCount(); i++) {
+                ItemStack one = stack.copy();
+                one.setCount(1);
+                units.add(new ItemUnit(entity, one));
+            }
+        }
+        return List.copyOf(units);
+    }
+
+    private static List<Scp914RecipeManager.ItemUse> collapseUses(List<ItemUnit> units) {
+        Map<ItemEntity, Integer> counts = new LinkedHashMap<>();
+        for (ItemUnit unit : units) counts.merge(unit.entity(), 1, Integer::sum);
+        List<Scp914RecipeManager.ItemUse> uses = new ArrayList<>();
+        counts.forEach((entity, count) -> uses.add(new Scp914RecipeManager.ItemUse(entity, count)));
+        return List.copyOf(uses);
+    }
+
+    private static List<ItemStack> craftingRemainders(List<ItemUnit> units) {
+        List<ItemStack> remainders = new ArrayList<>();
+        for (ItemUnit unit : units) {
+            ItemStack stack = unit.stack();
+            if (stack.hasCraftingRemainingItem()) {
+                ItemStack remainder = stack.getCraftingRemainingItem();
+                if (!remainder.isEmpty()) remainders.add(remainder.copy());
+            }
+        }
+        return remainders;
+    }
+
+    private static List<ItemStack> roughRecovery(List<ItemStack> ingredients, RandomSource random) {
+        if (ingredients.isEmpty() || random.nextFloat() < 0.28F) return List.of();
+        ItemStack selected = ingredients.get(random.nextInt(ingredients.size())).copy();
+        selected.setCount(1);
+        return List.of(selected);
+    }
+
+    private static List<ItemStack> coarseRecovery(List<ItemStack> ingredients, RandomSource random) {
+        List<ItemStack> recovered = new ArrayList<>();
+        for (ItemStack ingredient : ingredients) {
+            if (random.nextFloat() <= 0.68F) {
+                ItemStack copy = ingredient.copy();
+                copy.setCount(1);
+                recovered.add(copy);
+            }
+        }
+        if (recovered.isEmpty() && !ingredients.isEmpty()) {
+            ItemStack fallback = ingredients.get(random.nextInt(ingredients.size())).copy();
+            fallback.setCount(1);
+            recovered.add(fallback);
+        }
+        return recovered;
+    }
+
+    private static ItemStack chooseIngredientStack(Ingredient ingredient, RandomSource random) {
+        ItemStack[] choices = ingredient.getItems();
+        if (choices.length == 0) return ItemStack.EMPTY;
+        List<ItemStack> valid = new ArrayList<>();
+        for (ItemStack choice : choices) if (!choice.isEmpty()) valid.add(choice);
+        if (valid.isEmpty()) return ItemStack.EMPTY;
+        ItemStack selected = valid.get(random.nextInt(valid.size())).copy();
+        selected.setCount(1);
+        return selected;
+    }
+
+    private static List<ItemStack> combineStacks(List<ItemStack> stacks) {
+        Map<StackKey, ItemStack> combined = new LinkedHashMap<>();
+        for (ItemStack stack : stacks) {
+            if (stack == null || stack.isEmpty()) continue;
+            StackKey key = new StackKey(stack.getItem(), stack.getTag() == null ? "" : stack.getTag().toString());
+            ItemStack existing = combined.get(key);
+            if (existing == null) combined.put(key, stack.copy());
+            else existing.grow(stack.getCount());
+        }
+        return List.copyOf(combined.values());
+    }
+
+    private static boolean eligible(CraftingRecipe recipe) {
+        return recipe != null && !recipe.isSpecial() && !nonEmptyIngredients(recipe).isEmpty();
+    }
+
+    private static List<Ingredient> nonEmptyIngredients(CraftingRecipe recipe) {
+        List<Ingredient> ingredients = new ArrayList<>();
+        for (Ingredient ingredient : recipe.getIngredients()) {
+            if (ingredient != null && !ingredient.isEmpty()) ingredients.add(ingredient);
+        }
+        return ingredients;
+    }
+
+    private static ItemStack result(ServerLevel level, CraftingRecipe recipe) {
+        ItemStack result = recipe.getResultItem(level.registryAccess());
+        return result == null ? ItemStack.EMPTY : result.copy();
+    }
+
+    private static List<CraftingRecipe> recipes(ServerLevel level) {
+        return level.getRecipeManager().getAllRecipesFor(RecipeType.CRAFTING);
+    }
+
+    private static boolean isEquivalentCategory(Item input, Item output) {
+        if (input instanceof ArmorItem inputArmor && output instanceof ArmorItem outputArmor) {
+            return inputArmor.getEquipmentSlot() == outputArmor.getEquipmentSlot();
+        }
+        if (input instanceof SwordItem && output instanceof SwordItem) return true;
+        if (input instanceof DiggerItem && output instanceof DiggerItem) return true;
+        if (input instanceof ProjectileWeaponItem && output instanceof ProjectileWeaponItem) return true;
+        return input.getClass() != Item.class && input.getClass().equals(output.getClass())
+                && input.getMaxStackSize() == output.getMaxStackSize();
+    }
+
+    private static String settingName(Scp914RecipeManager.Setting setting) {
+        return setting.serializedName();
+    }
+
+    private static <T> T random(List<T> values, RandomSource random) {
+        return values.get(random.nextInt(values.size()));
+    }
+
+    public record GenericMatch(String setting, ResourceLocation sourceRecipe,
+                               List<Scp914RecipeManager.ItemUse> itemUses,
+                               List<ItemStack> outputs) {
+    }
+
+    private record ItemUnit(ItemEntity entity, ItemStack stack) {
+    }
+
+    private record ForwardCandidate(ResourceLocation recipeId, List<ItemUnit> assignment,
+                                    ItemStack result) {
+    }
+
+    private record ReverseCandidate(ResourceLocation recipeId, List<ItemStack> ingredients) {
+    }
+
+    private record RecipeResult(ResourceLocation recipeId, ItemStack stack) {
+    }
+
+    private record StackKey(Item item, String tag) {
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914Processor.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914Processor.java
@@ -108,7 +108,7 @@ public final class Scp914Processor {
                 .toList();
 
         Optional<Scp914RecipeManager.RecipeMatch> match =
-                Scp914RecipeManager.findRecipe(setting, itemInputs, entityInputs);
+                Scp914RecipeBridge.findRecipe(level, setting, itemInputs, entityInputs);
         return new ProcessingContext(match, players, intakeCenter, outputCenter);
     }
 

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeBridge.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeBridge.java
@@ -1,0 +1,66 @@
+package net.mcreator.scpadditions.data;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** Keeps explicit JSON recipes authoritative and supplies generic fallbacks only when needed. */
+public final class Scp914RecipeBridge {
+    private Scp914RecipeBridge() {
+    }
+
+    public static Optional<Scp914RecipeManager.RecipeMatch> findRecipe(
+            ServerLevel level,
+            Scp914RecipeManager.Setting setting,
+            List<ItemEntity> itemEntities,
+            List<Entity> entities) {
+        Optional<Scp914RecipeManager.RecipeMatch> explicit =
+                Scp914RecipeManager.findRecipe(setting, itemEntities, entities);
+        if (explicit.isPresent()) return explicit;
+
+        // A generic item transformation must never silently ignore an entity
+        // that is also standing in the intake. Entity behavior remains explicit.
+        if (entities != null && !entities.isEmpty()) return Optional.empty();
+
+        return Scp914GenericRecipeResolver.find(level, setting, itemEntities)
+                .flatMap(match -> convert(setting, match));
+    }
+
+    private static Optional<Scp914RecipeManager.RecipeMatch> convert(
+            Scp914RecipeManager.Setting setting,
+            Scp914GenericRecipeResolver.GenericMatch generic) {
+        List<Scp914RecipeManager.ItemOutput> outputs = new ArrayList<>();
+        for (ItemStack stack : generic.outputs()) {
+            if (stack == null || stack.isEmpty()) continue;
+            ResourceLocation id = ForgeRegistries.ITEMS.getKey(stack.getItem());
+            if (id == null) continue;
+            outputs.add(new Scp914RecipeManager.ItemOutput(id, stack.getCount()));
+        }
+
+        ResourceLocation syntheticId = new ResourceLocation("scp_additions",
+                "inferred/" + setting.serializedName() + "/"
+                        + generic.sourceRecipe().getNamespace() + "/"
+                        + generic.sourceRecipe().getPath());
+        Scp914RecipeManager.RecipeDefinition definition =
+                new Scp914RecipeManager.RecipeDefinition(
+                        syntheticId,
+                        setting,
+                        List.of(),
+                        List.of(),
+                        List.copyOf(outputs),
+                        List.of(),
+                        List.of(),
+                        1.0F,
+                        false,
+                        "");
+        return Optional.of(new Scp914RecipeManager.RecipeMatch(
+                definition, generic.itemUses(), List.of()));
+    }
+}


### PR DESCRIPTION
Experimental server-side fallback that derives SCP-914 item transformations from loaded crafting recipes only when no explicit SCP-914 JSON recipe matches.

- Rough: lossy single-component breakdown
- Coarse: incomplete disassembly
- 1:1: random ambiguous or narrowly equivalent result
- Fine: exact unordered crafting ingredients
- Very Fine: Fine result plus one homogeneous crafting step when possible
- Explicit JSON recipes remain authoritative
- Special recipes, extra intake items, mixed entity inputs and unsafe quantity reversal are excluded

This PR is intentionally isolated for compilation, balance and gameplay testing before any merge.