### PR TITLE
Integrate polished configuration UI and SCP-914 fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,20 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build
-        run: ./gradlew clean build --stacktrace
+        id: gradle-build
+        shell: bash
+        run: |
+          set +e
+          ./gradlew clean build --stacktrace > build.log 2>&1
+          status=$?
+          cat build.log
+          exit $status
+
+      - name: Upload diagnostic build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-build-log
+          path: build.log
+          if-no-files-found: ignore
+          retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,20 +34,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build
-        id: gradle-build
-        shell: bash
-        run: |
-          set +e
-          ./gradlew clean build --stacktrace > build.log 2>&1
-          status=$?
-          cat build.log
-          exit $status
-
-      - name: Upload diagnostic build log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-build-log
-          path: build.log
-          if-no-files-found: ignore
-          retention-days: 1
+        run: ./gradlew clean build --stacktrace

--- a/src/main/java/com/bl4ues/scpinventory/client/gui/ItemConfigScreen.java
+++ b/src/main/java/com/bl4ues/scpinventory/client/gui/ItemConfigScreen.java
@@ -1,5 +1,6 @@
 package com.bl4ues.scpinventory.client.gui;
 
+import com.bl4ues.scpinventory.client.ScpFonts;
 import com.bl4ues.scpinventory.item.ScpItemType;
 import com.bl4ues.scpinventory.network.ItemConfigDeletePacket;
 import com.bl4ues.scpinventory.network.ItemConfigOpenPacket;
@@ -9,12 +10,23 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 
 public class ItemConfigScreen extends Screen {
-    private static final int PANEL_W = 270;
-    private static final int PANEL_H = 250;
+    private static final int PANEL_W = 310;
+    private static final int PANEL_H = 270;
     private static final int MARGIN = 10;
+    private static final int NAVY = 0xF000071F;
+    private static final int NAVY_LIGHT = 0xE6141E42;
+    private static final int BORDER = 0xFF46536C;
+    private static final int ACCENT = 0xFFC59A2A;
+    private static final int WHITE = 0xFFF7F8FC;
+    private static final int MUTED = 0xFFA9AFBA;
+    private static final int SECTION = 0xFFD3D9E4;
+    private static final int DANGER = 0xFFFF8F8F;
     private static final ScpItemType[] TYPES = ScpItemType.values();
 
     private final String itemId;
@@ -29,7 +41,7 @@ public class ItemConfigScreen extends Screen {
     private boolean confirmForget;
 
     public ItemConfigScreen(ItemConfigOpenPacket packet) {
-        super(Component.literal("SCP Item Config Editor"));
+        super(ScpFonts.roboto("SCP Item Config Editor"));
         this.itemId = packet.itemId();
         this.existing = packet.existing();
         this.type = parseType(packet.type());
@@ -41,48 +53,79 @@ public class ItemConfigScreen extends Screen {
     protected void init() {
         int left = panelLeft();
         int top = panelTop();
-        int x = left + 12;
-        int y = top + 58;
+        int x = left + 16;
+        int y = top + 78;
+        int width = PANEL_W - 32;
 
-        typeButton = addRenderableWidget(Button.builder(Component.literal(typeText()), b -> {
+        typeButton = addRenderableWidget(Button.builder(ScpFonts.roboto(typeText()), b -> {
             type = TYPES[(type.ordinal() + 1) % TYPES.length];
-            b.setMessage(Component.literal(typeText()));
-        }).bounds(x, y, PANEL_W - 24, 20).build());
+            b.setMessage(ScpFonts.roboto(typeText()));
+        }).bounds(x, y, width, 22).build());
 
-        y += 30;
-        staminaButton = addRenderableWidget(Button.builder(Component.literal(staminaText()), b -> {
+        y += 38;
+        staminaButton = addRenderableWidget(Button.builder(ScpFonts.roboto(staminaText()), b -> {
             noStamina = !noStamina;
-            b.setMessage(Component.literal(staminaText()));
-        }).bounds(x, y, PANEL_W - 24, 20).build());
+            b.setMessage(ScpFonts.roboto(staminaText()));
+        }).bounds(x, y, width, 22).build());
 
         y += 30;
-        protectedEyesButton = addRenderableWidget(Button.builder(Component.literal(protectedEyesText()), b -> {
+        protectedEyesButton = addRenderableWidget(Button.builder(ScpFonts.roboto(protectedEyesText()), b -> {
             protectedEyes = !protectedEyes;
-            b.setMessage(Component.literal(protectedEyesText()));
-        }).bounds(x, y, PANEL_W - 24, 20).build());
+            b.setMessage(ScpFonts.roboto(protectedEyesText()));
+        }).bounds(x, y, width, 22).build());
 
-        int bottomY = top + PANEL_H - 30;
-        forgetButton = addRenderableWidget(Button.builder(Component.literal("Forget"), b -> forgetRule()).bounds(left + 12, bottomY, 68, 20).build());
-        addRenderableWidget(Button.builder(Component.literal("Save"), b -> save()).bounds(left + PANEL_W - 154, bottomY, 68, 20).build());
-        addRenderableWidget(Button.builder(Component.literal("Cancel"), b -> onClose()).bounds(left + PANEL_W - 80, bottomY, 68, 20).build());
+        int bottomY = top + PANEL_H - 34;
+        forgetButton = addRenderableWidget(Button.builder(ScpFonts.roboto("Forget"), b -> forgetRule())
+                .bounds(left + 16, bottomY, 76, 22).build());
+        addRenderableWidget(Button.builder(ScpFonts.roboto("Save"), b -> save())
+                .bounds(left + PANEL_W - 172, bottomY, 76, 22).build());
+        addRenderableWidget(Button.builder(ScpFonts.roboto("Cancel"), b -> onClose())
+                .bounds(left + PANEL_W - 90, bottomY, 74, 22).build());
     }
 
     @Override
     public void render(GuiGraphics g, int mouseX, int mouseY, float partialTick) {
+        renderBackground(g);
         int left = panelLeft();
         int top = panelTop();
-        g.fill(left, top, left + PANEL_W, top + PANEL_H, 0xCC111317);
-        g.fill(left, top, left + PANEL_W, top + 24, 0xE525282D);
-        g.drawString(font, "SCP Item Config Editor", left + 12, top + 8, 0xFFE8E8E8, false);
-        g.drawString(font, (existing ? "Editing " : "New ") + compact(itemId, 32), left + 12, top + 30, 0xFFB5C7FF, false);
-        g.drawString(font, "Item category", left + 12, top + 48, 0xFFB7B7B7, false);
-        g.drawString(font, "Effects", left + 12, top + 84, 0xFFB7B7B7, false);
-        g.drawString(font, "Type writes item_rules[].", left + 12, top + 148, 0xFF999999, false);
-        g.drawString(font, "Effects write item_effects[].", left + 12, top + 162, 0xFF999999, false);
-        g.drawString(font, "Protected Eyes blocks external eye irritation.", left + 12, top + 176, 0xFF999999, false);
-        g.drawString(font, "Use CODEX for document items.", left + 12, top + 190, 0xFF88DDEE, false);
-        g.drawString(font, "Forget asks twice, then removes this item.", left + 12, top + 204, 0xFFFF9D9D, false);
+
+        g.fill(left, top, left + PANEL_W, top + PANEL_H, NAVY);
+        g.fill(left, top, left + PANEL_W, top + 31, NAVY_LIGHT);
+        g.fill(left, top + 30, left + PANEL_W, top + 31, ACCENT);
+        drawBorder(g, left, top, PANEL_W, PANEL_H, BORDER);
+
+        g.drawString(font, ScpFonts.roboto("SCP ITEM CONFIGURATION"), left + 14, top + 11, WHITE, false);
+
+        ItemStack preview = getPreviewStack();
+        int iconX = left + 16;
+        int iconY = top + 43;
+        g.fill(iconX - 3, iconY - 3, iconX + 19, iconY + 19, NAVY_LIGHT);
+        drawBorder(g, iconX - 3, iconY - 3, 22, 22, BORDER);
+        g.fill(iconX - 3, iconY - 3, iconX + 4, iconY - 2, ACCENT);
+        if (!preview.isEmpty()) g.renderItem(preview, iconX, iconY);
+
+        g.drawString(font, ScpFonts.roboto(existing ? "Editing explicit rule" : "Creating explicit rule"),
+                left + 46, top + 44, MUTED, false);
+        g.drawString(font, ScpFonts.roboto(compact(itemId, 42)), left + 46, top + 57, WHITE, false);
+
+        g.drawString(font, ScpFonts.roboto("CATEGORY"), left + 16, top + 69, SECTION, false);
+        g.drawString(font, ScpFonts.roboto("EQUIPMENT EFFECTS"), left + 16, top + 108, SECTION, false);
+
+        g.drawString(font, ScpFonts.roboto("Category controls storage, actions and equipment routing."),
+                left + 16, top + 177, MUTED, false);
+        g.drawString(font, ScpFonts.roboto("PLACEABLE is used automatically for blocks."),
+                left + 16, top + 190, MUTED, false);
+        g.drawString(font, ScpFonts.roboto("Forget removes the explicit rule and restores auto-detection."),
+                left + 16, top + 203, DANGER, false);
+
         super.render(g, mouseX, mouseY, partialTick);
+    }
+
+    private static void drawBorder(GuiGraphics g, int x, int y, int width, int height, int color) {
+        g.fill(x, y, x + width, y + 1, color);
+        g.fill(x, y + height - 1, x + width, y + height, color);
+        g.fill(x, y, x + 1, y + height, color);
+        g.fill(x + width - 1, y, x + width, y + height, color);
     }
 
     @Override
@@ -99,25 +142,29 @@ public class ItemConfigScreen extends Screen {
     private void forgetRule() {
         if (!confirmForget) {
             confirmForget = true;
-            if (forgetButton != null) {
-                forgetButton.setMessage(Component.literal("Confirm"));
-            }
+            if (forgetButton != null) forgetButton.setMessage(ScpFonts.roboto("Confirm"));
             return;
         }
         ModNetwork.CHANNEL.sendToServer(new ItemConfigDeletePacket(itemId));
         Minecraft.getInstance().setScreen(null);
     }
 
+    private ItemStack getPreviewStack() {
+        ResourceLocation id = ResourceLocation.tryParse(itemId);
+        if (id == null) return ItemStack.EMPTY;
+        return BuiltInRegistries.ITEM.getOptional(id).map(ItemStack::new).orElse(ItemStack.EMPTY);
+    }
+
     private String typeText() {
-        return "Type: " + type.name();
+        return "Category: " + type.getDisplayName();
     }
 
     private String staminaText() {
-        return noStamina ? "No Stamina: On" : "No Stamina: Off";
+        return noStamina ? "No Stamina: ON" : "No Stamina: OFF";
     }
 
     private String protectedEyesText() {
-        return protectedEyes ? "Protected Eyes: On" : "Protected Eyes: Off";
+        return protectedEyes ? "Protected Eyes: ON" : "Protected Eyes: OFF";
     }
 
     private int panelLeft() {
@@ -137,9 +184,7 @@ public class ItemConfigScreen extends Screen {
     }
 
     private static String compact(String text, int max) {
-        if (text == null || text.length() <= max) {
-            return text == null ? "" : text;
-        }
+        if (text == null || text.length() <= max) return text == null ? "" : text;
         return text.substring(0, Math.max(0, max - 3)) + "...";
     }
 }

--- a/src/main/java/com/bl4ues/scpinventory/client/gui/components/StatusPanel.java
+++ b/src/main/java/com/bl4ues/scpinventory/client/gui/components/StatusPanel.java
@@ -361,7 +361,7 @@ public class StatusPanel {
                 previewX + previewW / 2 - mouseX, previewY + 32 - mouseY, mc.player);
 
         int statX = parametersX + Math.round(parametersWidth * 0.64F);
-        int statY = previewY + 20;
+        int statY = parametersY + Math.round(parametersHeight * 0.13F) + 20;
         renderStat(g, "Max Health", Integer.toString(Math.round(mc.player.getMaxHealth())), statX, statY);
         renderStat(g, "Armor", Integer.toString(mc.player.getArmorValue()), statX, statY + 38);
         renderStat(g, "Toughness", formatAttribute(Attributes.ARMOR_TOUGHNESS), statX, statY + 76);

--- a/src/main/java/com/bl4ues/scpinventory/events/BlockPickupHandler.java
+++ b/src/main/java/com/bl4ues/scpinventory/events/BlockPickupHandler.java
@@ -1,28 +1,35 @@
 package com.bl4ues.scpinventory.events;
 
 import com.bl4ues.scpinventory.item.ScpPickupRouter;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
 
+import java.util.List;
+
 @Mod.EventBusSubscriber(modid = "scp_additions")
 public class BlockPickupHandler {
 
     @SubscribeEvent
     public static void onEntityJoinLevel(EntityJoinLevelEvent event) {
-        if (!ScpAdditionsModulesConfig.get().inventory.enabled) return;
-        if (event.getLevel().isClientSide()) {
-            return;
-        }
+        if (event.getLevel().isClientSide()) return;
 
         Entity entity = event.getEntity();
-        if (!(entity instanceof ItemEntity itemEntity) || itemEntity.getItem().isEmpty()) {
+        if (!(entity instanceof ItemEntity itemEntity) || itemEntity.getItem().isEmpty()) return;
+
+        if (!ScpAdditionsModulesConfig.get().inventory.enabled) {
+            ItemStack stack = itemEntity.getItem();
+            if (stripTransientInventoryTags(stack)) itemEntity.setItem(stack);
             return;
         }
 
@@ -63,12 +70,58 @@ public class BlockPickupHandler {
 
     @SubscribeEvent
     public static void onItemPickup(EntityItemPickupEvent event) {
-        if (!ScpAdditionsModulesConfig.get().inventory.enabled) return;
         Player player = event.getEntity();
-        if (player.level().isClientSide() || player.isCreative() || player.isSpectator()) {
+        if (player.level().isClientSide()) return;
+
+        ItemStack stack = event.getItem().getItem();
+        if (!ScpAdditionsModulesConfig.get().inventory.enabled || player.isCreative() || player.isSpectator()) {
+            if (stripTransientInventoryTags(stack)) event.getItem().setItem(stack);
             return;
         }
 
         event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || event.player.level().isClientSide()
+                || ScpAdditionsModulesConfig.get().inventory.enabled
+                || !(event.player instanceof ServerPlayer player)
+                || player.tickCount % 20 != 0) {
+            return;
+        }
+
+        Inventory inventory = player.getInventory();
+        boolean changed = stripTransientInventoryTags(inventory.items)
+                | stripTransientInventoryTags(inventory.offhand)
+                | stripTransientInventoryTags(inventory.armor);
+        if (player.containerMenu != null) {
+            ItemStack carried = player.containerMenu.getCarried();
+            changed |= stripTransientInventoryTags(carried);
+        }
+        if (changed) {
+            inventory.setChanged();
+            player.inventoryMenu.broadcastChanges();
+            if (player.containerMenu != player.inventoryMenu) player.containerMenu.broadcastChanges();
+        }
+    }
+
+    private static boolean stripTransientInventoryTags(List<ItemStack> stacks) {
+        boolean changed = false;
+        for (ItemStack stack : stacks) changed |= stripTransientInventoryTags(stack);
+        return changed;
+    }
+
+    private static boolean stripTransientInventoryTags(ItemStack stack) {
+        if (stack == null || stack.isEmpty() || !stack.hasTag()) return false;
+        CompoundTag tag = stack.getTag();
+        if (tag == null) return false;
+        boolean changed = tag.contains(ScpPickupRouter.NO_MERGE_TAG)
+                || tag.contains(ScpPickupRouter.USABLE_SESSION_TAG)
+                || tag.contains(ScpPickupRouter.USABLE_START_TICK_TAG);
+        if (!changed) return false;
+        ScpPickupRouter.stripNoMergeMarker(stack);
+        ScpPickupRouter.stripUsableSession(stack);
+        return true;
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/client/UnityColorPickerScreen.java
+++ b/src/main/java/net/mcreator/scpadditions/client/UnityColorPickerScreen.java
@@ -1,0 +1,189 @@
+package net.mcreator.scpadditions.client;
+
+import com.bl4ues.scpinventory.client.ScpFonts;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import java.util.Locale;
+import java.util.function.Consumer;
+
+/** Small RGB picker used by JSON-backed editors without external UI dependencies. */
+public final class UnityColorPickerScreen extends Screen {
+    private static final int NAVY = 0xF000071F;
+    private static final int NAVY_LIGHT = 0xF0141E42;
+    private static final int BORDER = 0xFF46536C;
+    private static final int ACCENT = 0xFFC59A2A;
+    private static final int WHITE = 0xFFF7F8FC;
+    private static final int MUTED = 0xFFA9AFBA;
+
+    private final Screen parent;
+    private final Consumer<String> callback;
+    private int red;
+    private int green;
+    private int blue;
+    private EditBox hexBox;
+    private ChannelSlider redSlider;
+    private ChannelSlider greenSlider;
+    private ChannelSlider blueSlider;
+    private boolean syncing;
+
+    public UnityColorPickerScreen(Screen parent, String initial, Consumer<String> callback) {
+        super(ScpFonts.roboto("Choose a Color"));
+        this.parent = parent;
+        this.callback = callback;
+        int rgb = parse(initial, 0xFFFFFF);
+        this.red = rgb >> 16 & 255;
+        this.green = rgb >> 8 & 255;
+        this.blue = rgb & 255;
+    }
+
+    @Override
+    protected void init() {
+        int panelW = Math.min(430, width - 24);
+        int left = (width - panelW) / 2;
+        int top = Math.max(12, (height - 265) / 2);
+        int x = left + 24;
+        int sliderW = panelW - 48;
+
+        redSlider = addRenderableWidget(new ChannelSlider(x, top + 62, sliderW, "Red", red,
+                value -> { red = value; updateHexFromSliders(); }));
+        greenSlider = addRenderableWidget(new ChannelSlider(x, top + 94, sliderW, "Green", green,
+                value -> { green = value; updateHexFromSliders(); }));
+        blueSlider = addRenderableWidget(new ChannelSlider(x, top + 126, sliderW, "Blue", blue,
+                value -> { blue = value; updateHexFromSliders(); }));
+
+        hexBox = new EditBox(font, x, top + 164, sliderW, 20, ScpFonts.roboto("Hex color"));
+        hexBox.setFormatter((value, cursor) -> ScpFonts.roboto(value).getVisualOrderText());
+        hexBox.setMaxLength(7);
+        hexBox.setValue(hex());
+        hexBox.setResponder(this::updateSlidersFromHex);
+        addRenderableWidget(hexBox);
+
+        int buttonY = top + 205;
+        addRenderableWidget(Button.builder(ScpFonts.roboto("Apply"), button -> {
+            if (callback != null) callback.accept(hex());
+            Minecraft.getInstance().setScreen(parent);
+        }).bounds(x, buttonY, (sliderW - 8) / 2, 22).build());
+        addRenderableWidget(Button.builder(ScpFonts.roboto("Cancel"), button -> Minecraft.getInstance().setScreen(parent))
+                .bounds(x + (sliderW - 8) / 2 + 8, buttonY, (sliderW - 8) / 2, 22).build());
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        renderBackground(graphics);
+        int panelW = Math.min(430, width - 24);
+        int left = (width - panelW) / 2;
+        int top = Math.max(12, (height - 265) / 2);
+        int right = left + panelW;
+        int bottom = top + 250;
+
+        graphics.fill(left, top, right, bottom, NAVY);
+        graphics.fill(left, top, right, top + 34, NAVY_LIGHT);
+        graphics.fill(left, top + 33, right, top + 34, ACCENT);
+        drawBorder(graphics, left, top, panelW, bottom - top, BORDER);
+        graphics.drawString(font, ScpFonts.roboto("SCP UNITY COLOR PICKER"), left + 16, top + 12, WHITE, false);
+
+        int previewX = right - 74;
+        int previewY = top + 43;
+        graphics.fill(previewX, previewY, previewX + 50, previewY + 12, 0xFF000000 | rgb());
+        drawBorder(graphics, previewX, previewY, 50, 12, BORDER);
+        graphics.fill(previewX, previewY, previewX + 8, previewY + 1, ACCENT);
+        graphics.drawString(font, ScpFonts.roboto("Preview"), left + 24, top + 46, MUTED, false);
+        graphics.drawString(font, ScpFonts.roboto("Hexadecimal and sliders stay synchronized."),
+                left + 24, top + 188, MUTED, false);
+
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+
+    private static void drawBorder(GuiGraphics graphics, int x, int y, int width, int height, int color) {
+        graphics.fill(x, y, x + width, y + 1, color);
+        graphics.fill(x, y + height - 1, x + width, y + height, color);
+        graphics.fill(x, y, x + 1, y + height, color);
+        graphics.fill(x + width - 1, y, x + width, y + height, color);
+    }
+
+    @Override
+    public void onClose() {
+        Minecraft.getInstance().setScreen(parent);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    private void updateHexFromSliders() {
+        if (hexBox == null || syncing) return;
+        syncing = true;
+        hexBox.setValue(hex());
+        syncing = false;
+    }
+
+    private void updateSlidersFromHex(String value) {
+        if (syncing || value == null || !value.matches("#[0-9A-Fa-f]{6}")) return;
+        int rgb = parse(value, rgb());
+        red = rgb >> 16 & 255;
+        green = rgb >> 8 & 255;
+        blue = rgb & 255;
+        syncing = true;
+        redSlider.setChannel(red);
+        greenSlider.setChannel(green);
+        blueSlider.setChannel(blue);
+        syncing = false;
+    }
+
+    private int rgb() {
+        return red << 16 | green << 8 | blue;
+    }
+
+    private String hex() {
+        return String.format(Locale.ROOT, "#%06X", rgb());
+    }
+
+    private static int parse(String value, int fallback) {
+        if (value == null) return fallback;
+        String clean = value.trim();
+        if (clean.startsWith("#")) clean = clean.substring(1);
+        try {
+            return clean.matches("[0-9A-Fa-f]{6}") ? Integer.parseInt(clean, 16) : fallback;
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+
+    private static final class ChannelSlider extends AbstractSliderButton {
+        private final String label;
+        private final Consumer<Integer> callback;
+
+        private ChannelSlider(int x, int y, int width, String label, int channel, Consumer<Integer> callback) {
+            super(x, y, width, 20, Component.empty(), channel / 255.0D);
+            this.label = label;
+            this.callback = callback;
+            updateMessage();
+        }
+
+        @Override
+        protected void updateMessage() {
+            setMessage(ScpFonts.roboto(label + ": " + channel()));
+        }
+
+        @Override
+        protected void applyValue() {
+            if (callback != null) callback.accept(channel());
+        }
+
+        private int channel() {
+            return Math.max(0, Math.min(255, (int) Math.round(value * 255.0D)));
+        }
+
+        private void setChannel(int channel) {
+            value = Math.max(0.0D, Math.min(1.0D, channel / 255.0D));
+            updateMessage();
+        }
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/client/UnityConfigurationUiEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/client/UnityConfigurationUiEvents.java
@@ -90,7 +90,7 @@ public final class UnityConfigurationUiEvents {
                 editBox.setTextColor(WHITE);
                 editBox.setTextColorUneditable(MUTED);
             }
-            if (listener instanceof AbstractButton button && !(button instanceof AbstractSliderButton)) {
+            if (listener instanceof AbstractButton button) {
                 Component current = button.getMessage();
                 if (current != null && !current.getString().isBlank()) {
                     BUTTON_LABELS.put(button, ScpFonts.roboto(current));
@@ -116,7 +116,7 @@ public final class UnityConfigurationUiEvents {
         renderKnownHeader(graphics, screen);
         renderKnownBodyText(graphics, screen);
         for (GuiEventListener listener : screen.children()) {
-            if (!(listener instanceof AbstractButton button) || button instanceof AbstractSliderButton || !button.visible) continue;
+            if (!(listener instanceof AbstractButton button) || !button.visible) continue;
             Component label = labelFor(button);
             String plain = label.getString();
             drawButton(graphics, font, button, label, mouseX, mouseY);
@@ -139,7 +139,7 @@ public final class UnityConfigurationUiEvents {
 
         // Restore labels after rendering so narration and button callbacks still see them.
         for (GuiEventListener listener : screen.children()) {
-            if (listener instanceof AbstractButton button && !(button instanceof AbstractSliderButton)) {
+            if (listener instanceof AbstractButton button) {
                 Component label = BUTTON_LABELS.get(button);
                 if (label != null) button.setMessage(label);
             }

--- a/src/main/java/net/mcreator/scpadditions/client/UnityConfigurationUiEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/client/UnityConfigurationUiEvents.java
@@ -1,0 +1,630 @@
+package net.mcreator.scpadditions.client;
+
+import com.bl4ues.scpinventory.client.ScpFonts;
+import com.bl4ues.scpinventory.client.gui.ItemConfigScreen;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.client.gui.components.AbstractSliderButton;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ScreenEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.mcreator.scpadditions.init.ScpAdditionsModItems;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Native SCP Unity presentation shared by the configuration center and the K editor.
+ * The original widgets retain their behavior; their labels are hidden only while the
+ * frame is rendered so Roboto text and the subdued navy/slate/gold hierarchy can be
+ * drawn once without the vanilla text showing underneath.
+ */
+@Mod.EventBusSubscriber(modid = "scp_additions", value = Dist.CLIENT)
+public final class UnityConfigurationUiEvents {
+    private static final int PANEL = 0xEE111317;
+    private static final int HEADER = 0xEE24282E;
+    private static final int NAVY = 0xF0081022;
+    private static final int NAVY_HOVER = 0xF0131E36;
+    private static final int NAVY_DISABLED = 0xE01B1E26;
+    private static final int BORDER = 0xFF46536C;
+    private static final int BORDER_HOVER = 0xFF73809A;
+    private static final int ACCENT = 0xFFC59A2A;
+    private static final int ACCENT_SOFT = 0xFF8D711F;
+    private static final int PALE_GOLD = 0xFFE5D49A;
+    private static final int WHITE = 0xFFF7F8FC;
+    private static final int MUTED = 0xFF9CA3AF;
+    private static final int DANGER = 0xFFD46060;
+    private static final List<String> ITEM_TYPES = List.of(
+            "MISCELLANEOUS", "CONSUMABLE", "USABLE", "PLACEABLE", "HARMFUL",
+            "KEY", "COIN", "AMMO", "HEAD", "CHEST", "LEGS", "FEET",
+            "ACCESSORY", "ACCESSORYHAND", "WEAPON", "CODEX");
+    private static final Map<String, String> TOOLTIPS = buildTooltips();
+    private static final Map<AbstractButton, Component> BUTTON_LABELS = new WeakHashMap<>();
+
+    private UnityConfigurationUiEvents() {
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onScreenInit(ScreenEvent.Init.Post event) {
+        Screen screen = event.getScreen();
+        if (!isConfigurationScreen(screen)) return;
+
+        for (GuiEventListener listener : event.getListenersList()) prepareWidget(listener);
+
+        String name = screen.getClass().getSimpleName();
+        if ("DrinkDetailScreen".equals(name)) installDrinkColorPicker(event, screen);
+        if ("ItemRuleDetailScreen".equals(name)) installPlaceableCategory(event, screen);
+        if ("CodexListScreen".equals(name)) installPaperDocumentDefault(event, screen);
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onScreenRenderPre(ScreenEvent.Render.Pre event) {
+        Screen screen = event.getScreen();
+        if (!isConfigurationScreen(screen)) return;
+        for (GuiEventListener listener : screen.children()) {
+            if (listener instanceof EditBox editBox) {
+                editBox.setFormatter((value, cursor) -> ScpFonts.roboto(value).getVisualOrderText());
+                editBox.setTextColor(WHITE);
+                editBox.setTextColorUneditable(MUTED);
+            }
+            if (listener instanceof AbstractButton button && !(button instanceof AbstractSliderButton)) {
+                Component current = button.getMessage();
+                if (current != null && !current.getString().isBlank()) {
+                    BUTTON_LABELS.put(button, ScpFonts.roboto(current));
+                }
+                button.setMessage(Component.empty());
+            }
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onScreenRenderPost(ScreenEvent.Render.Post event) {
+        Screen screen = event.getScreen();
+        if (!isConfigurationScreen(screen)) return;
+
+        GuiGraphics graphics = event.getGuiGraphics();
+        int mouseX = event.getMouseX();
+        int mouseY = event.getMouseY();
+        Font font = Minecraft.getInstance().font;
+        Component hoveredTooltip = null;
+
+        graphics.pose().pushPose();
+        graphics.pose().translate(0.0F, 0.0F, 420.0F);
+        renderKnownHeader(graphics, screen);
+        renderKnownBodyText(graphics, screen);
+        for (GuiEventListener listener : screen.children()) {
+            if (!(listener instanceof AbstractButton button) || button instanceof AbstractSliderButton || !button.visible) continue;
+            Component label = labelFor(button);
+            String plain = label.getString();
+            drawButton(graphics, font, button, label, mouseX, mouseY);
+            if (contains(button, mouseX, mouseY)) {
+                String tooltip = tooltipFor(plain);
+                if (!tooltip.isBlank()) hoveredTooltip = ScpFonts.roboto(tooltip);
+            }
+        }
+        graphics.pose().popPose();
+
+        graphics.pose().pushPose();
+        graphics.pose().translate(0.0F, 0.0F, 430.0F);
+        String name = screen.getClass().getSimpleName();
+        if ("DrinkListScreen".equals(name)) renderDrinkRows(graphics, screen);
+        if ("ItemRulesScreen".equals(name)) renderItemRuleRows(graphics, screen);
+        if ("RecipeListScreen".equals(name)) renderRecipeRows(graphics, screen);
+        graphics.pose().popPose();
+
+        if (hoveredTooltip != null) graphics.renderTooltip(font, hoveredTooltip, mouseX, mouseY);
+
+        // Restore labels after rendering so narration and button callbacks still see them.
+        for (GuiEventListener listener : screen.children()) {
+            if (listener instanceof AbstractButton button && !(button instanceof AbstractSliderButton)) {
+                Component label = BUTTON_LABELS.get(button);
+                if (label != null) button.setMessage(label);
+            }
+        }
+    }
+
+    private static void prepareWidget(GuiEventListener listener) {
+        if (listener instanceof AbstractSliderButton slider) {
+            slider.setMessage(ScpFonts.roboto(slider.getMessage()));
+        } else if (listener instanceof AbstractButton button) {
+            Component label = ScpFonts.roboto(button.getMessage());
+            BUTTON_LABELS.put(button, label);
+            button.setMessage(Component.empty());
+        } else if (listener instanceof EditBox editBox) {
+            editBox.setFormatter((value, cursor) -> ScpFonts.roboto(value).getVisualOrderText());
+            editBox.setTextColor(WHITE);
+            editBox.setTextColorUneditable(MUTED);
+        }
+    }
+
+    private static void drawButton(GuiGraphics graphics, Font font, AbstractButton button,
+                                   Component label, int mouseX, int mouseY) {
+        boolean hovered = contains(button, mouseX, mouseY);
+        String plain = label.getString();
+        boolean danger = isDanger(plain);
+        boolean primary = isPrimary(plain);
+
+        int background = !button.active ? NAVY_DISABLED : hovered ? NAVY_HOVER : NAVY;
+        int border = danger ? DANGER : hovered ? BORDER_HOVER : BORDER;
+        int stripe = danger ? DANGER : primary ? ACCENT : hovered ? ACCENT_SOFT : BORDER;
+        int text = !button.active ? MUTED : primary && !danger ? PALE_GOLD : WHITE;
+
+        int x = button.getX();
+        int y = button.getY();
+        int right = x + button.getWidth();
+        int bottom = y + button.getHeight();
+        graphics.fill(x, y, right, bottom, background);
+        graphics.fill(x, y, right, y + 1, border);
+        graphics.fill(x, bottom - 1, right, bottom, border);
+        graphics.fill(x, y, x + 1, bottom, border);
+        graphics.fill(right - 1, y, right, bottom, border);
+        graphics.fill(x + 1, y + 1, x + (primary || danger || hovered ? 4 : 2), bottom - 1, stripe);
+
+        int textX = x + Math.max(5, (button.getWidth() - font.width(label)) / 2);
+        int textY = y + Math.max(1, (button.getHeight() - 8) / 2);
+        graphics.drawString(font, label, textX, textY, text, false);
+    }
+
+    private static Component labelFor(AbstractButton button) {
+        Component saved = BUTTON_LABELS.get(button);
+        if (saved != null) return saved;
+        Component current = button.getMessage();
+        return current == null ? Component.empty() : ScpFonts.roboto(current);
+    }
+
+    private static void installDrinkColorPicker(ScreenEvent.Init.Post event, Screen screen) {
+        EditBox colorBox = readField(screen, "colorBox", EditBox.class);
+        if (colorBox == null || colorBox.getWidth() < 120) return;
+        int originalWidth = colorBox.getWidth();
+        colorBox.setWidth(Math.max(76, originalWidth - 96));
+        Button picker = Button.builder(ScpFonts.roboto("Pick Color"), button -> {
+            invokeNoArgs(screen, "sync");
+            JsonObject edit = readField(screen, "edit", JsonObject.class);
+            String initial = edit == null ? colorBox.getValue() : string(edit, "cup_color", colorBox.getValue());
+            Minecraft.getInstance().setScreen(new UnityColorPickerScreen(screen, initial, selected -> {
+                if (edit != null) edit.addProperty("cup_color", selected);
+                colorBox.setValue(selected);
+            }));
+        }).bounds(colorBox.getX() + colorBox.getWidth() + 6, colorBox.getY(), 90, 20).build();
+        prepareWidget(picker);
+        event.addListener(picker);
+    }
+
+    private static void installPlaceableCategory(ScreenEvent.Init.Post event, Screen screen) {
+        Button old = readField(screen, "typeButton", Button.class);
+        if (old == null) return;
+        Component oldLabel = BUTTON_LABELS.getOrDefault(old, ScpFonts.roboto("Category: MISCELLANEOUS"));
+        event.removeListener(old);
+        BUTTON_LABELS.remove(old);
+        Button replacement = Button.builder(oldLabel, button -> {
+            String current = readField(screen, "type", String.class);
+            int index = ITEM_TYPES.indexOf(current == null ? "MISCELLANEOUS" : current.toUpperCase(Locale.ROOT));
+            String next = ITEM_TYPES.get((Math.max(0, index) + 1) % ITEM_TYPES.size());
+            writeField(screen, "type", next);
+            Component label = ScpFonts.roboto("Category: " + next);
+            BUTTON_LABELS.put(button, label);
+            button.setMessage(label);
+        }).bounds(old.getX(), old.getY(), old.getWidth(), old.getHeight()).build();
+        writeField(screen, "typeButton", replacement);
+        prepareWidget(replacement);
+        event.addListener(replacement);
+    }
+
+    private static void installPaperDocumentDefault(ScreenEvent.Init.Post event, Screen screen) {
+        List<GuiEventListener> snapshot = new ArrayList<>(event.getListenersList());
+        for (GuiEventListener listener : snapshot) {
+            if (!(listener instanceof Button button)) continue;
+            String label = BUTTON_LABELS.getOrDefault(button, button.getMessage()).getString();
+            if (!"+ Add Document".equals(label)) continue;
+            event.removeListener(button);
+            BUTTON_LABELS.remove(button);
+            Button replacement = Button.builder(ScpFonts.roboto("+ Paper Document"), ignored -> addPaperDocument(screen))
+                    .bounds(button.getX(), button.getY(), button.getWidth(), button.getHeight()).build();
+            prepareWidget(replacement);
+            event.addListener(replacement);
+        }
+    }
+
+    private static void addPaperDocument(Screen parent) {
+        JsonObject root = readField(parent, "root", JsonObject.class);
+        if (root == null) return;
+        JsonArray documents = array(root, "codex_documents");
+        JsonObject document = new JsonObject();
+        document.addProperty("id", "minecraft:paper");
+        document.addProperty("category", "Documents");
+        document.addProperty("name", "New Document");
+        document.addProperty("image", "");
+        document.addProperty("text", "");
+        documents.add(document);
+        Screen detail = constructNestedScreen(
+                "net.mcreator.scpadditions.config.ui.ConfigCenterClient$CodexDetailScreen",
+                parent, document);
+        if (detail != null) Minecraft.getInstance().setScreen(detail);
+    }
+
+    private static void renderKnownHeader(GuiGraphics graphics, Screen screen) {
+        PanelSpec spec = panelSpec(screen);
+        if (spec == null) return;
+        graphics.fill(spec.x(), spec.y(), spec.x() + spec.width(), spec.y() + 26, HEADER);
+        graphics.drawString(Minecraft.getInstance().font, ScpFonts.roboto(screen.getTitle()),
+                spec.x() + 10, spec.y() + 9, WHITE, false);
+    }
+
+    private static void renderKnownBodyText(GuiGraphics graphics, Screen screen) {
+        PanelSpec spec = panelSpec(screen);
+        if (spec == null) return;
+        Font font = Minecraft.getInstance().font;
+        String name = screen.getClass().getSimpleName();
+        if ("HomeScreen".equals(name)) {
+            graphics.fill(spec.x() + 8, spec.y() + 27, spec.x() + spec.width() - 8, spec.y() + 43, PANEL);
+            graphics.drawString(font, ScpFonts.roboto("Server-authoritative JSON editors with validation and automatic .bak backups."),
+                    spec.x() + 14, spec.y() + 31, MUTED, false);
+        } else if ("InventoryHubScreen".equals(name)) {
+            graphics.fill(spec.x() + 8, spec.y() + 27, spec.x() + spec.width() - 8, spec.y() + 43, PANEL);
+            graphics.drawString(font, ScpFonts.roboto("Edits remain local until Save All is pressed."),
+                    spec.x() + 14, spec.y() + 31, MUTED, false);
+        } else if ("MessageScreen".equals(name)) {
+            String message = readField(screen, "message", String.class);
+            Boolean passive = readField(screen, "passive", Boolean.class);
+            graphics.fill(spec.x() + 8, spec.y() + 27, spec.x() + spec.width() - 8, spec.y() + spec.height() - 8, PANEL);
+            int lineY = spec.y() + 42;
+            for (net.minecraft.util.FormattedCharSequence line : font.split(ScpFonts.roboto(message == null ? "" : message), spec.width() - 24)) {
+                graphics.drawString(font, line, spec.x() + 12, lineY, Boolean.TRUE.equals(passive) ? MUTED : DANGER, false);
+                lineY += 11;
+            }
+        }
+    }
+
+    private static PanelSpec panelSpec(Screen screen) {
+        String name = screen.getClass().getSimpleName();
+        int w;
+        int h;
+        int y;
+        switch (name) {
+            case "MessageScreen" -> { w = Math.min(430, screen.width - 20); h = 130; y = Math.max(12, screen.height / 2 - 65); }
+            case "HomeScreen" -> { w = Math.min(420, screen.width - 20); h = Math.min(300, screen.height - 20); y = Math.max(10, (screen.height - h) / 2); }
+            case "ModulesScreen" -> { w = Math.min(560, screen.width - 20); h = Math.min(380, screen.height - 16); y = Math.max(8, (screen.height - h) / 2); }
+            case "InventoryHubScreen" -> { w = Math.min(430, screen.width - 20); h = Math.min(300, screen.height - 20); y = Math.max(10, (screen.height - h) / 2); }
+            case "ItemRulesScreen" -> { w = Math.min(650, screen.width - 16); h = Math.min(400, screen.height - 16); y = Math.max(8, (screen.height - h) / 2); }
+            case "ItemRuleDetailScreen" -> { w = Math.min(430, screen.width - 20); h = 280; y = Math.max(10, (screen.height - h) / 2); }
+            case "IdListScreen" -> { w = Math.min(600, screen.width - 18); h = Math.min(380, screen.height - 16); y = Math.max(8, (screen.height - h) / 2); }
+            case "DrinkListScreen" -> { w = Math.min(700, screen.width - 16); h = Math.min(410, screen.height - 16); y = Math.max(8, (screen.height - h) / 2); }
+            case "RecipeListScreen" -> { w = Math.min(760, screen.width - 12); h = Math.min(440, screen.height - 12); y = Math.max(6, (screen.height - h) / 2); }
+            case "MachineSettingsScreen" -> { w = Math.min(620, screen.width - 18); h = 360; y = Math.max(9, (screen.height - h) / 2); }
+            default -> { return null; }
+        }
+        return new PanelSpec(Math.max(8, (screen.width - w) / 2), y, w, h);
+    }
+
+    private static void renderDrinkRows(GuiGraphics graphics, Screen screen) {
+        List<JsonObject> filtered = readJsonObjectList(screen, "filtered");
+        Integer scrollValue = readField(screen, "scroll", Integer.class);
+        int scroll = scrollValue == null ? 0 : scrollValue;
+        int w = Math.min(700, screen.width - 16);
+        int x = (screen.width - w) / 2 + 12;
+        int top = Math.max(8, (screen.height - Math.min(410, screen.height - 16)) / 2) + 38;
+        int listY = top + 30;
+        int visible = Math.max(5, Math.min(11, (screen.height - 132) / 24));
+        Font font = Minecraft.getInstance().font;
+
+        for (int i = scroll; i < Math.min(filtered.size(), scroll + visible); i++) {
+            JsonObject drink = filtered.get(i);
+            int rowY = listY + (i - scroll) * 24;
+            int rowRight = x + w - 150;
+            drawSummaryCard(graphics, x, rowY, rowRight, rowY + 20);
+            graphics.renderItem(coloredCup(string(drink, "cup_color", "#FFFFFF")), x + 7, rowY + 2);
+            String id = string(drink, "id", "unknown");
+            String alias = firstAlias(drink);
+            String label = id + (alias.isBlank() ? "" : " — “" + alias + "”")
+                    + (bool(drink, "enabled", true) ? "" : " [disabled]");
+            graphics.enableScissor(x + 26, rowY, rowRight - 5, rowY + 20);
+            graphics.drawString(font, ScpFonts.roboto(label), x + 29, rowY + 6,
+                    bool(drink, "enabled", true) ? WHITE : MUTED, false);
+            graphics.disableScissor();
+        }
+    }
+
+    private static void renderItemRuleRows(GuiGraphics graphics, Screen screen) {
+        List<JsonObject> filtered = readJsonObjectList(screen, "filtered");
+        Integer scrollValue = readField(screen, "scroll", Integer.class);
+        int scroll = scrollValue == null ? 0 : scrollValue;
+        int w = Math.min(650, screen.width - 16);
+        int x = (screen.width - w) / 2 + 12;
+        int top = Math.max(8, (screen.height - Math.min(400, screen.height - 16)) / 2) + 38;
+        int listY = top + 30;
+        int visible = Math.max(4, Math.min(10, (screen.height - 128) / 24));
+        Font font = Minecraft.getInstance().font;
+
+        for (int i = scroll; i < Math.min(filtered.size(), scroll + visible); i++) {
+            JsonObject rule = filtered.get(i);
+            int rowY = listY + (i - scroll) * 24;
+            int rowRight = x + w - 78;
+            drawSummaryCard(graphics, x, rowY, rowRight, rowY + 20);
+            String id = string(rule, "id", "unknown");
+            ItemStack stack = itemStack(id);
+            if (!stack.isEmpty()) graphics.renderItem(stack, x + 7, rowY + 2);
+            String label = id + "  [" + string(rule, "type", "MISCELLANEOUS") + "]";
+            graphics.enableScissor(x + 26, rowY, rowRight - 5, rowY + 20);
+            graphics.drawString(font, ScpFonts.roboto(label), x + 29, rowY + 6, WHITE, false);
+            graphics.disableScissor();
+        }
+    }
+
+    private static void renderRecipeRows(GuiGraphics graphics, Screen screen) {
+        List<?> filtered = readList(screen, "filtered");
+        Integer scrollValue = readField(screen, "scroll", Integer.class);
+        int scroll = scrollValue == null ? 0 : scrollValue;
+        int w = Math.min(760, screen.width - 12);
+        int x = (screen.width - w) / 2 + 12;
+        int top = Math.max(6, (screen.height - Math.min(440, screen.height - 12)) / 2) + 38;
+        int listY = top + 30;
+        int visible = Math.max(5, Math.min(12, (screen.height - 130) / 24));
+        int rowRight = x + w - 154;
+        Font font = Minecraft.getInstance().font;
+
+        for (int i = scroll; i < Math.min(filtered.size(), scroll + visible); i++) {
+            Object ref = filtered.get(i);
+            JsonObject recipe = readField(ref, "recipe", JsonObject.class);
+            String source = readField(ref, "source", String.class);
+            if (recipe == null) continue;
+            int rowY = listY + (i - scroll) * 24;
+            drawSummaryCard(graphics, x, rowY, rowRight, rowY + 20);
+
+            ItemStack input = firstRecipeItem(recipe, "item_inputs");
+            ItemStack output = firstRecipeItem(recipe, "item_outputs");
+            if (output.isEmpty()) output = firstRecipeItem(recipe, "weighted_item_outputs");
+            if (!input.isEmpty()) graphics.renderItem(input, x + 7, rowY + 2);
+            graphics.drawString(font, ScpFonts.roboto("→"), x + 26, rowY + 6, PALE_GOLD, false);
+            if (!output.isEmpty()) graphics.renderItem(output, x + 38, rowY + 2);
+
+            String setting = string(recipe, "setting", "?");
+            String sourceName = source == null ? "?" : source.startsWith("914/") ? source.substring(4) : source;
+            String id = string(recipe, "id", "unknown");
+            int badgeWidth = Math.min(112, Math.max(62, font.width(ScpFonts.roboto(setting)) + 14));
+            int badgeX = rowRight - badgeWidth - 4;
+            graphics.fill(badgeX, rowY + 3, rowRight - 4, rowY + 17, 0xD0182239);
+            graphics.fill(badgeX, rowY + 3, badgeX + 2, rowY + 17, ACCENT_SOFT);
+            graphics.drawString(font, ScpFonts.roboto(setting), badgeX + 7, rowY + 6, PALE_GOLD, false);
+
+            graphics.enableScissor(x + 58, rowY, badgeX - 5, rowY + 20);
+            graphics.drawString(font, ScpFonts.roboto(id + "  ‹" + sourceName + "›"), x + 61, rowY + 6, WHITE, false);
+            graphics.disableScissor();
+        }
+    }
+
+    private static void drawSummaryCard(GuiGraphics graphics, int left, int top, int right, int bottom) {
+        graphics.fill(left, top, right, bottom, NAVY);
+        graphics.fill(left, top, left + 2, bottom, ACCENT_SOFT);
+        graphics.fill(left, top, right, top + 1, BORDER);
+        graphics.fill(left, bottom - 1, right, bottom, BORDER);
+    }
+
+    private static ItemStack firstRecipeItem(JsonObject recipe, String key) {
+        if (recipe == null || !recipe.has(key) || !recipe.get(key).isJsonArray()) return ItemStack.EMPTY;
+        for (JsonElement element : recipe.getAsJsonArray(key)) {
+            if (!element.isJsonObject()) continue;
+            ItemStack stack = itemStack(string(element.getAsJsonObject(), "item", ""));
+            if (!stack.isEmpty()) return stack;
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private static ItemStack itemStack(String id) {
+        ResourceLocation resource = ResourceLocation.tryParse(id == null ? "" : id);
+        return resource == null ? ItemStack.EMPTY
+                : BuiltInRegistries.ITEM.getOptional(resource).map(ItemStack::new).orElse(ItemStack.EMPTY);
+    }
+
+    private static ItemStack coloredCup(String hex) {
+        ItemStack stack = new ItemStack(ScpAdditionsModItems.CUP_OF_COFFEE.get());
+        CompoundTag drink = new CompoundTag();
+        drink.putInt("cup_color", parseColor(hex, 0xFFFFFF));
+        stack.getOrCreateTag().put("Scp294Drink", drink);
+        return stack;
+    }
+
+    private static boolean isConfigurationScreen(Screen screen) {
+        if (screen == null) return false;
+        if (screen instanceof ItemConfigScreen || screen instanceof UnityColorPickerScreen) return true;
+        return screen.getClass().getName().startsWith("net.mcreator.scpadditions.config.ui.ConfigCenterClient$");
+    }
+
+    private static boolean contains(AbstractButton button, int mouseX, int mouseY) {
+        return mouseX >= button.getX() && mouseX < button.getX() + button.getWidth()
+                && mouseY >= button.getY() && mouseY < button.getY() + button.getHeight();
+    }
+
+    private static boolean isDanger(String label) {
+        String value = normalize(label);
+        return value.equals("x") || value.startsWith("delete") || value.startsWith("remove")
+                || value.startsWith("forget") || value.startsWith("confirm");
+    }
+
+    private static boolean isPrimary(String label) {
+        String value = normalize(label);
+        return value.startsWith("save") || value.startsWith("done") || value.startsWith("create")
+                || value.startsWith("+ add") || value.startsWith("+ new")
+                || value.startsWith("+ paper") || value.startsWith("apply");
+    }
+
+    private static String tooltipFor(String label) {
+        String normalized = normalize(label);
+        for (Map.Entry<String, String> entry : TOOLTIPS.entrySet()) {
+            if (normalized.equals(entry.getKey()) || normalized.startsWith(entry.getKey() + ":")
+                    || normalized.startsWith(entry.getKey() + " ")) return entry.getValue();
+        }
+        if (normalized.startsWith("category")) return "Choose how this item is stored and used by SCP Inventory.";
+        if (normalized.startsWith("type")) return "Choose the SCP Inventory category assigned to this item.";
+        if (normalized.contains("on") || normalized.contains("off")) return "Toggle this setting. Changes are applied only after saving.";
+        if (normalized.startsWith("x")) return "Remove this entry from the working configuration.";
+        return "Open or modify this configuration entry.";
+    }
+
+    private static String normalize(String text) {
+        return text == null ? "" : text.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static Map<String, String> buildTooltips() {
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put("general & modules", "Enable or disable gameplay, HUD, blink, interaction and SCP systems.");
+        values.put("inventory, equipment & codex", "Edit item categories, equipment effects, Status filters and Codex documents.");
+        values.put("contextual interactions", "Edit prompts and right-click actions attached to blocks and entities.");
+        values.put("scp-294 drinks", "Create, search and edit drinks, aliases, colors, effects and machine actions.");
+        values.put("scp-914 recipes", "Create and edit intake, setting, output and advanced transformations.");
+        values.put("item categories & equipment effects", "Classify items and assign supported equipment modifiers.");
+        values.put("hidden status effects", "Choose effects hidden from the custom Conditions panel.");
+        values.put("scp-173 entity targets", "Choose entities participating in SCP-173 observation and targeting rules.");
+        values.put("codex documents", "Create document definitions shown in the SCP Inventory Codex.");
+        values.put("reload snapshot", "Discard unsaved local edits and request the server configuration again.");
+        values.put("save & reload", "Validate, save with a .bak backup and reload the affected system.");
+        values.put("save all", "Validate and save every edited section in this group.");
+        values.put("save rule", "Save this item category and its equipment effects.");
+        values.put("save", "Validate and save the current changes.");
+        values.put("defaults", "Restore the default values on this screen before saving.");
+        values.put("back", "Return to the previous configuration screen.");
+        values.put("cancel", "Discard unsaved changes on this screen.");
+        values.put("done", "Close the configuration center.");
+        values.put("forget", "Remove the explicit rule and return the item to automatic classification.");
+        values.put("confirm", "Confirm the destructive removal action.");
+        values.put("+ add item", "Search the loaded item registry and create a new item rule.");
+        values.put("+ new drink", "Create a new SCP-294 drink definition.");
+        values.put("+ recipe", "Create a new SCP-914 recipe in the in-game editor fragment.");
+        values.put("+ paper document", "Create a Codex definition using minecraft:paper as its temporary item.");
+        values.put("pick color", "Choose the cup color with synchronized RGB sliders and hexadecimal input.");
+        values.put("duplicate", "Create an independent copy of this entry for faster editing.");
+        values.put("additional recipe settings", "Show less common chance, NBT, action-bar and weighted-output options.");
+        return Map.copyOf(values);
+    }
+
+    private static Screen constructNestedScreen(String className, Screen parent, JsonObject object) {
+        try {
+            Class<?> type = Class.forName(className);
+            Constructor<?> constructor = type.getDeclaredConstructor(Screen.class, JsonObject.class);
+            constructor.setAccessible(true);
+            return (Screen) constructor.newInstance(parent, object);
+        } catch (ReflectiveOperationException ignored) {
+            return null;
+        }
+    }
+
+    private static void invokeNoArgs(Object target, String name) {
+        if (target == null) return;
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Method method = type.getDeclaredMethod(name);
+                method.setAccessible(true);
+                method.invoke(target);
+                return;
+            } catch (ReflectiveOperationException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+    }
+
+    private static <T> T readField(Object target, String name, Class<T> expected) {
+        Object value = readField(target, name);
+        return expected.isInstance(value) ? expected.cast(value) : null;
+    }
+
+    private static Object readField(Object target, String name) {
+        if (target == null) return null;
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField(name);
+                field.setAccessible(true);
+                return field.get(target);
+            } catch (ReflectiveOperationException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    private static void writeField(Object target, String name, Object value) {
+        if (target == null) return;
+        Class<?> type = target.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField(name);
+                field.setAccessible(true);
+                field.set(target, value);
+                return;
+            } catch (ReflectiveOperationException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+    }
+
+    private static List<JsonObject> readJsonObjectList(Object target, String name) {
+        List<?> list = readList(target, name);
+        List<JsonObject> values = new ArrayList<>();
+        for (Object value : list) if (value instanceof JsonObject object) values.add(object);
+        return values;
+    }
+
+    private static List<?> readList(Object target, String name) {
+        Object raw = readField(target, name);
+        return raw instanceof List<?> list ? list : List.of();
+    }
+
+    private static JsonArray array(JsonObject root, String key) {
+        if (!root.has(key) || !root.get(key).isJsonArray()) root.add(key, new JsonArray());
+        return root.getAsJsonArray(key);
+    }
+
+    private static String string(JsonObject object, String key, String fallback) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) return fallback;
+        try { return object.get(key).getAsString(); }
+        catch (Exception ignored) { return fallback; }
+    }
+
+    private static boolean bool(JsonObject object, String key, boolean fallback) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) return fallback;
+        try { return object.get(key).getAsBoolean(); }
+        catch (Exception ignored) { return fallback; }
+    }
+
+    private static String firstAlias(JsonObject drink) {
+        if (drink == null || !drink.has("aliases") || !drink.get("aliases").isJsonArray()) return "";
+        JsonArray aliases = drink.getAsJsonArray("aliases");
+        if (aliases.isEmpty()) return "";
+        JsonElement first = aliases.get(0);
+        return first.isJsonPrimitive() ? first.getAsString() : "";
+    }
+
+    private static int parseColor(String value, int fallback) {
+        if (value == null) return fallback;
+        String clean = value.trim();
+        if (clean.startsWith("#")) clean = clean.substring(1);
+        try { return clean.matches("[0-9A-Fa-f]{6}") ? Integer.parseInt(clean, 16) : fallback; }
+        catch (NumberFormatException ignored) { return fallback; }
+    }
+
+    private record PanelSpec(int x, int y, int width, int height) {
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914GenericRecipeResolver.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914GenericRecipeResolver.java
@@ -1,0 +1,488 @@
+package net.mcreator.scpadditions.data;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.AxeItem;
+import net.minecraft.world.item.DiggerItem;
+import net.minecraft.world.item.HoeItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.PickaxeItem;
+import net.minecraft.world.item.ProjectileWeaponItem;
+import net.minecraft.world.item.ShovelItem;
+import net.minecraft.world.item.SwordItem;
+import net.minecraft.world.item.Tier;
+import net.minecraft.world.item.TieredItem;
+import net.minecraft.world.item.Tiers;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeType;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Derives conservative SCP-914 transformations from recipes loaded by the server.
+ * Explicit SCP-914 JSON definitions are still evaluated by {@link Scp914RecipeBridge}.
+ */
+public final class Scp914GenericRecipeResolver {
+    private static final int MAX_INTAKE_UNITS = 256;
+
+    private Scp914GenericRecipeResolver() {
+    }
+
+    public static Optional<GenericMatch> find(ServerLevel level,
+                                              Scp914RecipeManager.Setting setting,
+                                              List<ItemEntity> itemEntities) {
+        if (level == null || itemEntities == null || itemEntities.isEmpty()) return Optional.empty();
+        return switch (setting) {
+            case ROUGH -> findReverse(level, itemEntities, true);
+            case COARSE -> findReverse(level, itemEntities, false);
+            case ONE_TO_ONE -> findOneToOne(level, itemEntities);
+            case FINE -> findForward(level, itemEntities, false);
+            case VERY_FINE -> findForward(level, itemEntities, true);
+        };
+    }
+
+    private static Optional<GenericMatch> findForward(ServerLevel level,
+                                                       List<ItemEntity> entities,
+                                                       boolean veryFine) {
+        List<ItemUnit> units = expandUnits(entities);
+        if (units.isEmpty()) return Optional.empty();
+
+        List<ForwardCandidate> candidates = collectForwardCandidates(level, units);
+        if (candidates.isEmpty()) return Optional.empty();
+        ForwardCandidate selected = selectMostComplete(candidates, level.random);
+
+        ItemStack output = selected.result().copy();
+        ResourceLocation resolvedRecipe = selected.recipeId();
+        if (veryFine) {
+            Optional<RecipeResult> successor = findHomogeneousSuccessor(level, output);
+            if (successor.isPresent()) {
+                output = successor.get().stack();
+                resolvedRecipe = successor.get().recipeId();
+            }
+        }
+
+        List<ItemStack> outputs = new ArrayList<>();
+        outputs.add(output);
+        outputs.addAll(craftingRemainders(selected.assignment()));
+        return Optional.of(new GenericMatch(
+                veryFine ? Scp914RecipeManager.Setting.VERY_FINE : Scp914RecipeManager.Setting.FINE,
+                resolvedRecipe,
+                collapseUses(selected.assignment()),
+                combineStacks(outputs),
+                selected.assignment().size(),
+                units.size()));
+    }
+
+    private static List<ForwardCandidate> collectForwardCandidates(ServerLevel level, List<ItemUnit> units) {
+        List<ForwardCandidate> candidates = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            List<Ingredient> ingredients = nonEmptyIngredients(recipe);
+            if (ingredients.isEmpty() || ingredients.size() > units.size()) continue;
+            Optional<List<ItemUnit>> assignment = assignIngredients(ingredients, units);
+            if (assignment.isEmpty()) continue;
+            ItemStack result = result(level, recipe);
+            if (result.isEmpty()) continue;
+            candidates.add(new ForwardCandidate(recipe.getId(), assignment.get(), result));
+        }
+        return candidates;
+    }
+
+    private static ForwardCandidate selectMostComplete(List<ForwardCandidate> candidates, RandomSource random) {
+        int bestUse = candidates.stream().mapToInt(candidate -> candidate.assignment().size()).max().orElse(0);
+        List<ForwardCandidate> best = candidates.stream()
+                .filter(candidate -> candidate.assignment().size() == bestUse)
+                .toList();
+        return random(best, random);
+    }
+
+    private static Optional<GenericMatch> findReverse(ServerLevel level,
+                                                       List<ItemEntity> entities,
+                                                       boolean rough) {
+        List<ItemUnit> units = expandUnits(entities);
+        if (units.size() != 1) return Optional.empty();
+        ItemUnit input = units.get(0);
+
+        List<ReverseCandidate> candidates = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            ItemStack result = result(level, recipe);
+            if (result.isEmpty() || result.getCount() != 1 || !ItemStack.isSameItem(result, input.stack())) continue;
+
+            List<ItemStack> recovered = new ArrayList<>();
+            for (Ingredient ingredient : nonEmptyIngredients(recipe)) {
+                ItemStack concrete = chooseIngredientStack(ingredient, level.random);
+                if (!concrete.isEmpty() && !ItemStack.isSameItem(concrete, input.stack())) recovered.add(concrete);
+            }
+            if (!recovered.isEmpty()) candidates.add(new ReverseCandidate(recipe.getId(), recovered));
+        }
+
+        List<ItemStack> synthetic = syntheticComponents(input.stack());
+        if (!synthetic.isEmpty()) {
+            ResourceLocation inputId = BuiltInRegistries.ITEM.getKey(input.stack().getItem());
+            String path = inputId == null ? "unknown" : inputId.getNamespace() + "/" + inputId.getPath();
+            candidates.add(new ReverseCandidate(
+                    new ResourceLocation("scp_additions", "inferred/disassembly/" + path), synthetic));
+        }
+        if (candidates.isEmpty()) return Optional.empty();
+
+        ReverseCandidate selected = random(candidates, level.random);
+        List<ItemStack> recovered = rough
+                ? roughRecovery(selected.ingredients(), level.random)
+                : coarseRecovery(selected.ingredients(), level.random);
+        return Optional.of(new GenericMatch(
+                rough ? Scp914RecipeManager.Setting.ROUGH : Scp914RecipeManager.Setting.COARSE,
+                selected.recipeId(),
+                List.of(new Scp914RecipeManager.ItemUse(input.entity(), 1)),
+                combineStacks(recovered),
+                1,
+                1));
+    }
+
+    private static Optional<GenericMatch> findOneToOne(ServerLevel level,
+                                                        List<ItemEntity> entities) {
+        List<ItemUnit> units = expandUnits(entities);
+        if (units.isEmpty()) return Optional.empty();
+
+        List<ForwardCandidate> direct = collectForwardCandidates(level, units);
+        if (!direct.isEmpty()) {
+            ForwardCandidate selected = selectMostComplete(direct, level.random);
+            List<ItemStack> outputs = new ArrayList<>();
+            outputs.add(selected.result().copy());
+            outputs.addAll(craftingRemainders(selected.assignment()));
+            return Optional.of(new GenericMatch(
+                    Scp914RecipeManager.Setting.ONE_TO_ONE,
+                    selected.recipeId(),
+                    collapseUses(selected.assignment()),
+                    combineStacks(outputs),
+                    selected.assignment().size(),
+                    units.size()));
+        }
+
+        if (units.size() != 1) return Optional.empty();
+        ItemUnit input = units.get(0);
+        List<RecipeResult> equivalents = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            ItemStack output = result(level, recipe);
+            if (output.isEmpty() || output.getCount() != 1 || ItemStack.isSameItem(output, input.stack())) continue;
+            if (isEquivalentCategory(input.stack().getItem(), output.getItem())
+                    && qualityCompatible(input.stack().getItem(), output.getItem())) {
+                equivalents.add(new RecipeResult(recipe.getId(), output));
+            }
+        }
+        if (equivalents.isEmpty()) return Optional.empty();
+
+        RecipeResult selected = random(equivalents, level.random);
+        return Optional.of(new GenericMatch(
+                Scp914RecipeManager.Setting.ONE_TO_ONE,
+                selected.recipeId(),
+                List.of(new Scp914RecipeManager.ItemUse(input.entity(), 1)),
+                List.of(selected.stack().copy()),
+                1,
+                1));
+    }
+
+    private static List<ItemStack> syntheticComponents(ItemStack input) {
+        if (input == null || input.isEmpty()) return List.of();
+        Item item = input.getItem();
+        List<ItemStack> components = new ArrayList<>();
+
+        if (item instanceof SwordItem && item instanceof TieredItem tiered) {
+            addRepeated(components, tierMaterial(tiered.getTier()), 2);
+            addRepeated(components, new ItemStack(Items.STICK), 1);
+            return components;
+        }
+        if (item instanceof DiggerItem && item instanceof TieredItem tiered) {
+            int materialCount = item instanceof ShovelItem ? 1 : item instanceof HoeItem ? 2 : 3;
+            addRepeated(components, tierMaterial(tiered.getTier()), materialCount);
+            addRepeated(components, new ItemStack(Items.STICK), 2);
+            return components;
+        }
+        if (item instanceof ArmorItem armor) {
+            ItemStack material = materialFromPath(item);
+            int count = switch (armor.getEquipmentSlot()) {
+                case HEAD -> 5;
+                case CHEST -> 8;
+                case LEGS -> 7;
+                case FEET -> 4;
+                default -> 0;
+            };
+            addRepeated(components, material, count);
+            return components;
+        }
+        return List.of();
+    }
+
+    private static ItemStack tierMaterial(Tier tier) {
+        if (tier == Tiers.WOOD) return new ItemStack(Items.OAK_PLANKS);
+        if (tier == Tiers.STONE) return new ItemStack(Items.COBBLESTONE);
+        if (tier == Tiers.IRON) return new ItemStack(Items.IRON_INGOT);
+        if (tier == Tiers.GOLD) return new ItemStack(Items.GOLD_INGOT);
+        if (tier == Tiers.DIAMOND) return new ItemStack(Items.DIAMOND);
+        if (tier == Tiers.NETHERITE) return new ItemStack(Items.NETHERITE_INGOT);
+        return ItemStack.EMPTY;
+    }
+
+    private static ItemStack materialFromPath(Item item) {
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(item);
+        String path = id == null ? "" : id.getPath();
+        if (path.contains("netherite")) return new ItemStack(Items.NETHERITE_INGOT);
+        if (path.contains("diamond")) return new ItemStack(Items.DIAMOND);
+        if (path.contains("gold")) return new ItemStack(Items.GOLD_INGOT);
+        if (path.contains("iron") || path.contains("chainmail")) return new ItemStack(Items.IRON_INGOT);
+        if (path.contains("leather")) return new ItemStack(Items.LEATHER);
+        return ItemStack.EMPTY;
+    }
+
+    private static void addRepeated(List<ItemStack> target, ItemStack template, int count) {
+        if (template == null || template.isEmpty() || count <= 0) return;
+        for (int i = 0; i < count; i++) {
+            ItemStack copy = template.copy();
+            copy.setCount(1);
+            target.add(copy);
+        }
+    }
+
+    private static Optional<RecipeResult> findHomogeneousSuccessor(ServerLevel level, ItemStack intermediate) {
+        if (intermediate.isEmpty()) return Optional.empty();
+        ItemStack one = intermediate.copy();
+        one.setCount(1);
+
+        List<RecipeResult> successors = new ArrayList<>();
+        for (CraftingRecipe recipe : recipes(level)) {
+            if (!eligible(recipe)) continue;
+            List<Ingredient> ingredients = nonEmptyIngredients(recipe);
+            if (ingredients.isEmpty() || ingredients.size() > intermediate.getCount()) continue;
+            boolean allMatch = true;
+            for (Ingredient ingredient : ingredients) {
+                if (!ingredient.test(one)) {
+                    allMatch = false;
+                    break;
+                }
+            }
+            if (!allMatch) continue;
+            ItemStack result = result(level, recipe);
+            if (result.isEmpty() || ItemStack.isSameItem(result, intermediate)) continue;
+            successors.add(new RecipeResult(recipe.getId(), result));
+        }
+        return successors.isEmpty() ? Optional.empty() : Optional.of(random(successors, level.random));
+    }
+
+    private static Optional<List<ItemUnit>> assignIngredients(List<Ingredient> ingredients,
+                                                               List<ItemUnit> units) {
+        boolean[] used = new boolean[units.size()];
+        List<ItemUnit> assignment = new ArrayList<>();
+        return assignRecursive(ingredients, units, 0, used, assignment)
+                ? Optional.of(List.copyOf(assignment)) : Optional.empty();
+    }
+
+    private static boolean assignRecursive(List<Ingredient> ingredients, List<ItemUnit> units,
+                                           int ingredientIndex, boolean[] used,
+                                           List<ItemUnit> assignment) {
+        if (ingredientIndex >= ingredients.size()) return true;
+        Ingredient ingredient = ingredients.get(ingredientIndex);
+        for (int i = 0; i < units.size(); i++) {
+            if (used[i] || !ingredient.test(units.get(i).stack())) continue;
+            used[i] = true;
+            assignment.add(units.get(i));
+            if (assignRecursive(ingredients, units, ingredientIndex + 1, used, assignment)) return true;
+            assignment.remove(assignment.size() - 1);
+            used[i] = false;
+        }
+        return false;
+    }
+
+    private static List<ItemUnit> expandUnits(List<ItemEntity> entities) {
+        int total = 0;
+        for (ItemEntity entity : entities) {
+            if (entity == null || entity.isRemoved() || entity.getItem().isEmpty()) continue;
+            total += entity.getItem().getCount();
+            if (total > MAX_INTAKE_UNITS) return List.of();
+        }
+        if (total <= 0) return List.of();
+
+        List<ItemUnit> units = new ArrayList<>(total);
+        for (ItemEntity entity : entities) {
+            if (entity == null || entity.isRemoved()) continue;
+            ItemStack stack = entity.getItem();
+            if (stack.isEmpty()) continue;
+            for (int i = 0; i < stack.getCount(); i++) {
+                ItemStack one = stack.copy();
+                one.setCount(1);
+                units.add(new ItemUnit(entity, one));
+            }
+        }
+        return List.copyOf(units);
+    }
+
+    private static List<Scp914RecipeManager.ItemUse> collapseUses(List<ItemUnit> units) {
+        Map<ItemEntity, Integer> counts = new LinkedHashMap<>();
+        for (ItemUnit unit : units) counts.merge(unit.entity(), 1, Integer::sum);
+        List<Scp914RecipeManager.ItemUse> uses = new ArrayList<>();
+        counts.forEach((entity, count) -> uses.add(new Scp914RecipeManager.ItemUse(entity, count)));
+        return List.copyOf(uses);
+    }
+
+    private static List<ItemStack> craftingRemainders(List<ItemUnit> units) {
+        List<ItemStack> remainders = new ArrayList<>();
+        for (ItemUnit unit : units) {
+            ItemStack stack = unit.stack();
+            if (stack.hasCraftingRemainingItem()) {
+                ItemStack remainder = stack.getCraftingRemainingItem();
+                if (!remainder.isEmpty()) remainders.add(remainder.copy());
+            }
+        }
+        return remainders;
+    }
+
+    private static List<ItemStack> roughRecovery(List<ItemStack> ingredients, RandomSource random) {
+        if (ingredients.isEmpty() || random.nextFloat() < 0.28F) return List.of();
+        ItemStack selected = ingredients.get(random.nextInt(ingredients.size())).copy();
+        selected.setCount(1);
+        return List.of(selected);
+    }
+
+    private static List<ItemStack> coarseRecovery(List<ItemStack> ingredients, RandomSource random) {
+        List<ItemStack> recovered = new ArrayList<>();
+        for (ItemStack ingredient : ingredients) {
+            if (random.nextFloat() <= 0.68F) {
+                ItemStack copy = ingredient.copy();
+                copy.setCount(1);
+                recovered.add(copy);
+            }
+        }
+        if (recovered.isEmpty() && !ingredients.isEmpty()) {
+            ItemStack fallback = ingredients.get(random.nextInt(ingredients.size())).copy();
+            fallback.setCount(1);
+            recovered.add(fallback);
+        }
+        return recovered;
+    }
+
+    private static ItemStack chooseIngredientStack(Ingredient ingredient, RandomSource random) {
+        ItemStack[] choices = ingredient.getItems();
+        if (choices.length == 0) return ItemStack.EMPTY;
+        List<ItemStack> valid = new ArrayList<>();
+        for (ItemStack choice : choices) if (!choice.isEmpty()) valid.add(choice);
+        if (valid.isEmpty()) return ItemStack.EMPTY;
+        ItemStack selected = valid.get(random.nextInt(valid.size())).copy();
+        selected.setCount(1);
+        return selected;
+    }
+
+    private static List<ItemStack> combineStacks(List<ItemStack> stacks) {
+        Map<StackKey, ItemStack> combined = new LinkedHashMap<>();
+        for (ItemStack stack : stacks) {
+            if (stack == null || stack.isEmpty()) continue;
+            StackKey key = new StackKey(stack.getItem(), stack.getTag() == null ? "" : stack.getTag().toString());
+            ItemStack existing = combined.get(key);
+            if (existing == null) combined.put(key, stack.copy());
+            else existing.grow(stack.getCount());
+        }
+        return List.copyOf(combined.values());
+    }
+
+    private static boolean eligible(CraftingRecipe recipe) {
+        return recipe != null && !recipe.isSpecial() && !nonEmptyIngredients(recipe).isEmpty();
+    }
+
+    private static List<Ingredient> nonEmptyIngredients(CraftingRecipe recipe) {
+        List<Ingredient> ingredients = new ArrayList<>();
+        for (Ingredient ingredient : recipe.getIngredients()) {
+            if (ingredient != null && !ingredient.isEmpty()) ingredients.add(ingredient);
+        }
+        return ingredients;
+    }
+
+    private static ItemStack result(ServerLevel level, CraftingRecipe recipe) {
+        ItemStack result = recipe.getResultItem(level.registryAccess());
+        return result == null ? ItemStack.EMPTY : result.copy();
+    }
+
+    private static List<CraftingRecipe> recipes(ServerLevel level) {
+        return level.getRecipeManager().getAllRecipesFor(RecipeType.CRAFTING);
+    }
+
+    private static boolean isEquivalentCategory(Item input, Item output) {
+        if (input instanceof ArmorItem inputArmor && output instanceof ArmorItem outputArmor) {
+            return inputArmor.getEquipmentSlot() == outputArmor.getEquipmentSlot();
+        }
+        if (input instanceof SwordItem && output instanceof SwordItem) return true;
+        if (input instanceof DiggerItem && output instanceof DiggerItem) return input.getClass().equals(output.getClass());
+        if (input instanceof ProjectileWeaponItem && output instanceof ProjectileWeaponItem) return true;
+        return input.getClass() != Item.class && input.getClass().equals(output.getClass())
+                && input.getMaxStackSize() == output.getMaxStackSize();
+    }
+
+    private static boolean qualityCompatible(Item input, Item output) {
+        int inputRank = qualityRank(input);
+        int outputRank = qualityRank(output);
+        return inputRank < 0 || outputRank < 0 || Math.abs(inputRank - outputRank) <= 1;
+    }
+
+    private static int qualityRank(Item item) {
+        if (item instanceof TieredItem tiered) return tierRank(tiered.getTier());
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(item);
+        String path = id == null ? "" : id.getPath();
+        if (path.contains("netherite")) return 5;
+        if (path.contains("diamond")) return 4;
+        if (path.contains("iron") || path.contains("chainmail")) return 3;
+        if (path.contains("gold")) return 2;
+        if (path.contains("stone")) return 1;
+        if (path.contains("wood") || path.contains("leather")) return 0;
+        return -1;
+    }
+
+    private static int tierRank(Tier tier) {
+        if (tier == Tiers.WOOD) return 0;
+        if (tier == Tiers.STONE) return 1;
+        if (tier == Tiers.GOLD) return 2;
+        if (tier == Tiers.IRON) return 3;
+        if (tier == Tiers.DIAMOND) return 4;
+        if (tier == Tiers.NETHERITE) return 5;
+        return -1;
+    }
+
+    private static <T> T random(List<T> values, RandomSource random) {
+        return values.get(random.nextInt(values.size()));
+    }
+
+    public record GenericMatch(Scp914RecipeManager.Setting setting,
+                               ResourceLocation sourceRecipe,
+                               List<Scp914RecipeManager.ItemUse> itemUses,
+                               List<ItemStack> outputs,
+                               int matchedInputCount,
+                               int totalInputCount) {
+        public boolean usesAllInputs() {
+            return totalInputCount > 0 && matchedInputCount >= totalInputCount;
+        }
+    }
+
+    private record ItemUnit(ItemEntity entity, ItemStack stack) {
+    }
+
+    private record ForwardCandidate(ResourceLocation recipeId, List<ItemUnit> assignment, ItemStack result) {
+    }
+
+    private record ReverseCandidate(ResourceLocation recipeId, List<ItemStack> ingredients) {
+    }
+
+    private record RecipeResult(ResourceLocation recipeId, ItemStack stack) {
+    }
+
+    private record StackKey(Item item, String tag) {
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914GenericRecipeResolver.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914GenericRecipeResolver.java
@@ -4,16 +4,13 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ArmorItem;
-import net.minecraft.world.item.AxeItem;
 import net.minecraft.world.item.DiggerItem;
 import net.minecraft.world.item.HoeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.PickaxeItem;
 import net.minecraft.world.item.ProjectileWeaponItem;
 import net.minecraft.world.item.ShovelItem;
 import net.minecraft.world.item.SwordItem;
@@ -200,14 +197,14 @@ public final class Scp914GenericRecipeResolver {
         Item item = input.getItem();
         List<ItemStack> components = new ArrayList<>();
 
-        if (item instanceof SwordItem && item instanceof TieredItem tiered) {
-            addRepeated(components, tierMaterial(tiered.getTier()), 2);
+        if (item instanceof SwordItem sword) {
+            addRepeated(components, tierMaterial(sword.getTier()), 2);
             addRepeated(components, new ItemStack(Items.STICK), 1);
             return components;
         }
-        if (item instanceof DiggerItem && item instanceof TieredItem tiered) {
+        if (item instanceof DiggerItem digger) {
             int materialCount = item instanceof ShovelItem ? 1 : item instanceof HoeItem ? 2 : 3;
-            addRepeated(components, tierMaterial(tiered.getTier()), materialCount);
+            addRepeated(components, tierMaterial(digger.getTier()), materialCount);
             addRepeated(components, new ItemStack(Items.STICK), 2);
             return components;
         }

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914Processor.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914Processor.java
@@ -69,7 +69,14 @@ public final class Scp914Processor {
         setRefining(world, true);
 
         ScpAdditionsMod.queueServerWork(machineConfig.startDelayTicks(), () -> {
-            context.match().ifPresent(match -> applyRecipe(level, context.outputCenter(), match));
+            if (context.match().isPresent()) {
+                applyRecipe(level, context.outputCenter(), context.match().get());
+            } else {
+                // A player makes this a valid cycle even when the loose items do
+                // not resolve to a recipe. Once the machine starts, everything in
+                // the intake belongs to SCP-914 and must not remain behind.
+                consumeLooseItems(context.itemInputs());
+            }
             for (ServerPlayer player : context.players()) {
                 processPlayer(player, context.outputCenter(), setting);
             }
@@ -108,8 +115,8 @@ public final class Scp914Processor {
                 .toList();
 
         Optional<Scp914RecipeManager.RecipeMatch> match =
-                Scp914RecipeManager.findRecipe(setting, itemInputs, entityInputs);
-        return new ProcessingContext(match, players, intakeCenter, outputCenter);
+                Scp914RecipeBridge.findRecipe(level, setting, itemInputs, entityInputs);
+        return new ProcessingContext(match, players, itemInputs, intakeCenter, outputCenter);
     }
 
     private static Scp914RecipeManager.Offset normalizeLegacyRangeOffset(Scp914RecipeManager.Offset offset) {
@@ -280,6 +287,12 @@ public final class Scp914Processor {
         }
     }
 
+    private static void consumeLooseItems(List<ItemEntity> items) {
+        for (ItemEntity item : items) {
+            if (item != null && !item.isRemoved()) item.discard();
+        }
+    }
+
     private static void closeDoorsImmediately(ServerLevel level, BlockPos keyPos) {
         boolean closedAnyDoor = false;
         for (BlockPos pos : BlockPos.betweenClosed(
@@ -359,6 +372,7 @@ public final class Scp914Processor {
     private record ProcessingContext(
             Optional<Scp914RecipeManager.RecipeMatch> match,
             List<ServerPlayer> players,
+            List<ItemEntity> itemInputs,
             Vec3 intakeCenter,
             Vec3 outputCenter) {
     }

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeBridge.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeBridge.java
@@ -1,0 +1,112 @@
+package net.mcreator.scpadditions.data;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Selects between explicit JSON recipes and inferred crafting behavior.
+ * Explicit definitions remain authoritative when they consume at least as much
+ * of the intake; a complete inferred recipe may beat a partial explicit match.
+ */
+public final class Scp914RecipeBridge {
+    private Scp914RecipeBridge() {
+    }
+
+    public static Optional<Scp914RecipeManager.RecipeMatch> findRecipe(
+            ServerLevel level,
+            Scp914RecipeManager.Setting setting,
+            List<ItemEntity> itemEntities,
+            List<Entity> entities) {
+        Optional<Scp914RecipeManager.RecipeMatch> selected = selectForSetting(
+                level, setting, itemEntities, entities);
+
+        // Very Fine may reuse a valid Fine transformation when no dedicated
+        // Very Fine path exists. This keeps curated Fine integrations useful
+        // while still allowing explicit Very Fine recipes to override them.
+        if (selected.isEmpty() && setting == Scp914RecipeManager.Setting.VERY_FINE) {
+            selected = selectForSetting(level, Scp914RecipeManager.Setting.FINE,
+                    itemEntities, entities);
+        }
+
+        return selected.map(match -> consumeCompleteIntake(match, itemEntities));
+    }
+
+    private static Optional<Scp914RecipeManager.RecipeMatch> selectForSetting(
+            ServerLevel level,
+            Scp914RecipeManager.Setting setting,
+            List<ItemEntity> itemEntities,
+            List<Entity> entities) {
+        Optional<Scp914RecipeManager.RecipeMatch> explicit =
+                Scp914RecipeManager.findRecipe(setting, itemEntities, entities);
+
+        Optional<Scp914GenericRecipeResolver.GenericMatch> generic = Optional.empty();
+        if (entities == null || entities.isEmpty()) {
+            generic = Scp914GenericRecipeResolver.find(level, setting, itemEntities);
+        }
+
+        if (explicit.isPresent() && generic.isPresent()) {
+            int explicitUse = explicit.get().itemUses().stream()
+                    .mapToInt(Scp914RecipeManager.ItemUse::count).sum();
+            if (generic.get().matchedInputCount() > explicitUse) {
+                return convert(setting, generic.get());
+            }
+            return explicit;
+        }
+        if (explicit.isPresent()) return explicit;
+        return generic.flatMap(match -> convert(setting, match));
+    }
+
+    private static Optional<Scp914RecipeManager.RecipeMatch> convert(
+            Scp914RecipeManager.Setting requestedSetting,
+            Scp914GenericRecipeResolver.GenericMatch generic) {
+        List<Scp914RecipeManager.ItemOutput> outputs = new ArrayList<>();
+        for (ItemStack stack : generic.outputs()) {
+            if (stack == null || stack.isEmpty()) continue;
+            ResourceLocation id = ForgeRegistries.ITEMS.getKey(stack.getItem());
+            if (id == null) continue;
+            outputs.add(new Scp914RecipeManager.ItemOutput(id, stack.getCount()));
+        }
+        if (outputs.isEmpty()) return Optional.empty();
+
+        ResourceLocation source = generic.sourceRecipe();
+        ResourceLocation syntheticId = new ResourceLocation("scp_additions",
+                "inferred/" + requestedSetting.serializedName() + "/"
+                        + source.getNamespace() + "/" + source.getPath());
+        Scp914RecipeManager.RecipeDefinition definition =
+                new Scp914RecipeManager.RecipeDefinition(
+                        syntheticId,
+                        requestedSetting,
+                        List.of(),
+                        List.of(),
+                        List.copyOf(outputs),
+                        List.of(),
+                        List.of(),
+                        1.0F,
+                        false,
+                        "");
+        return Optional.of(new Scp914RecipeManager.RecipeMatch(
+                definition, generic.itemUses(), List.of()));
+    }
+
+    private static Scp914RecipeManager.RecipeMatch consumeCompleteIntake(
+            Scp914RecipeManager.RecipeMatch match,
+            List<ItemEntity> itemEntities) {
+        List<Scp914RecipeManager.ItemUse> fullUses = new ArrayList<>();
+        if (itemEntities != null) {
+            for (ItemEntity entity : itemEntities) {
+                if (entity == null || entity.isRemoved() || entity.getItem().isEmpty()) continue;
+                fullUses.add(new Scp914RecipeManager.ItemUse(entity, entity.getItem().getCount()));
+            }
+        }
+        return new Scp914RecipeManager.RecipeMatch(
+                match.recipe(), List.copyOf(fullUses), match.entityUses());
+    }
+}


### PR DESCRIPTION
Integration candidate for 3.0.3 based on runtime feedback.

Configuration UI:
- subdued navy/slate palette with restrained gold accents
- Roboto button, field and known screen text
- suppress duplicated vanilla labels before drawing custom rows
- SCP-294 cup previews and RGB/hex color picker
- SCP-914 and item-rule icon summaries
- paper as temporary default Codex item
- parameters remain vertically centered while the player preview frame stays in its original position

SCP-914:
- loaded crafting recipes as fallback after curated JSON definitions
- favor transformations using the most intake material
- consume the complete item intake once a cycle begins
- material-aware Rough/Coarse decomposition for tiered equipment
- restrict extreme 1:1 tier downgrades
- allow Very Fine to reuse a valid Fine transformation when necessary

Inventory compatibility:
- remove transient no-merge/usable NBT when SCP Inventory is disabled or vanilla pickup is allowed

This PR is used to compile and review the integrated tree before fast-forwarding master.