### PR TITLE
CI verification: context save and SCP-914 fixes

### DIFF
--- a/.github/verification-context-save.txt
+++ b/.github/verification-context-save.txt
@@ -1,0 +1,1 @@
+Temporary CI verification marker for the integrated 3.0.3 context-save, SCP-914 precedence, and bundled-skin changes.


### PR DESCRIPTION
Temporary CI verification completed successfully. The standard Java 17 Gradle build passed against the current master code. This branch-only marker was not merged.