### PR TITLE
Add SCP-079 decision feed to debug HUD

### DIFF
--- a/src/main/java/net/mcreator/scpadditions/ScpAdditionsMod.java
+++ b/src/main/java/net/mcreator/scpadditions/ScpAdditionsMod.java
@@ -107,7 +107,7 @@ public class ScpAdditionsMod {
         Scp914SkinManager.initialize();
     }
 
-    private static final String PROTOCOL_VERSION = "10";
+    private static final String PROTOCOL_VERSION = "11";
     public static final SimpleChannel PACKET_HANDLER =
             NetworkRegistry.newSimpleChannel(
                     new ResourceLocation(MODID, MODID),

--- a/src/main/java/net/mcreator/scpadditions/client/Scp079EnergyClientState.java
+++ b/src/main/java/net/mcreator/scpadditions/client/Scp079EnergyClientState.java
@@ -6,11 +6,16 @@ import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.mcreator.scpadditions.ScpAdditionsMod;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog.DecisionOutcome;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog.DecisionType;
+import net.mcreator.scpadditions.network.Scp079DecisionPacket.DecisionEntry;
 import net.mcreator.scpadditions.network.Scp079EnergyPacket.RoamerEntry;
 import net.mcreator.scpadditions.roamer.RoamerResult;
 import net.mcreator.scpadditions.roamer.RoamerState;
 import net.mcreator.scpadditions.roamer.RoamerType;
 
+import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +29,8 @@ public final class Scp079EnergyClientState {
     private static boolean spawnTimersVisible;
     private static final Map<RoamerType, ClientRoamerSnapshot> ROAMERS =
             new EnumMap<>(RoamerType.class);
+    private static final List<ClientDecisionSnapshot> DECISIONS =
+            new ArrayList<>();
 
     private Scp079EnergyClientState() {
     }
@@ -35,6 +42,7 @@ public final class Scp079EnergyClientState {
         active = systemActive;
         energy = Math.max(0.0F, Math.min(100.0F, currentEnergy));
         spawnTimersVisible = shouldShowSpawnTimers;
+        if (!energyVisible) DECISIONS.clear();
         ROAMERS.clear();
         long now = clientGameTick();
         if (entries != null) {
@@ -43,6 +51,18 @@ public final class Scp079EnergyClientState {
                         entry.state(), entry.result(), entry.remainingTicks(),
                         now));
             }
+        }
+    }
+
+    public static void replaceDecisions(List<DecisionEntry> entries) {
+        DECISIONS.clear();
+        if (entries == null) return;
+        long now = clientGameTick();
+        for (DecisionEntry entry : entries) {
+            DECISIONS.add(new ClientDecisionSnapshot(entry.sequence(),
+                    entry.type(), entry.outcome(), entry.pos(),
+                    entry.dimension(), entry.context(), entry.cost(),
+                    entry.ageTicks(), now));
         }
     }
 
@@ -62,6 +82,18 @@ public final class Scp079EnergyClientState {
         return spawnTimersVisible;
     }
 
+    public static List<ClientDecisionSnapshot> decisions() {
+        long now = clientGameTick();
+        List<ClientDecisionSnapshot> visible = new ArrayList<>();
+        for (ClientDecisionSnapshot decision : DECISIONS) {
+            if (decision.ageTicks(now)
+                    < Scp079DecisionLog.CLIENT_LIFETIME_TICKS) {
+                visible.add(decision);
+            }
+        }
+        return List.copyOf(visible);
+    }
+
     public static ClientRoamerSnapshot roamer(RoamerType type) {
         ClientRoamerSnapshot snapshot = ROAMERS.get(type);
         if (snapshot != null) return snapshot;
@@ -77,6 +109,7 @@ public final class Scp079EnergyClientState {
         energy = 0.0F;
         spawnTimersVisible = false;
         ROAMERS.clear();
+        DECISIONS.clear();
     }
 
     private static long clientGameTick() {
@@ -87,6 +120,31 @@ public final class Scp079EnergyClientState {
     @SubscribeEvent
     public static void onLoggingOut(ClientPlayerNetworkEvent.LoggingOut event) {
         clear();
+    }
+
+    public record ClientDecisionSnapshot(long sequence, DecisionType type,
+            DecisionOutcome outcome, net.minecraft.core.BlockPos pos,
+            String dimension, String context, float cost,
+            int ageTicksAtSync, long clientTickAtSync) {
+        public ClientDecisionSnapshot {
+            if (type == null) type = DecisionType.ABORTED_ACTION;
+            if (outcome == null) outcome = DecisionOutcome.ABORTED;
+            if (pos == null) pos = net.minecraft.core.BlockPos.ZERO;
+            if (dimension == null) dimension = "";
+            if (context == null) context = "";
+            cost = Math.max(0.0F, cost);
+            ageTicksAtSync = Math.max(0, ageTicksAtSync);
+        }
+
+        public int ageTicks() {
+            return ageTicks(clientGameTick());
+        }
+
+        private int ageTicks(long now) {
+            long elapsed = Math.max(0L, now - clientTickAtSync);
+            return (int) Math.min(Integer.MAX_VALUE,
+                    ageTicksAtSync + elapsed);
+        }
     }
 
     public record ClientRoamerSnapshot(RoamerState state, RoamerResult result,

--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079DecisionLog.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079DecisionLog.java
@@ -1,0 +1,100 @@
+package net.mcreator.scpadditions.facility;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Event-driven history of meaningful SCP-079 decisions for the developer HUD.
+ * Routine evaluations that choose to do nothing are intentionally omitted, so
+ * the feed reflects actual manipulation and deliberate strategic abandonment.
+ */
+public final class Scp079DecisionLog {
+    public static final int CLIENT_LIFETIME_TICKS = 300;
+    private static final int MAX_HISTORY = 12;
+    private static final int MAX_CONTEXT_LENGTH = 160;
+    private static final Map<MinecraftServer, History> HISTORIES =
+            new WeakHashMap<>();
+
+    private Scp079DecisionLog() {
+    }
+
+    public static void record(ServerLevel level, DecisionType type,
+            DecisionOutcome outcome, BlockPos pos, double cost,
+            String context) {
+        MinecraftServer server = level == null ? null : level.getServer();
+        if (server == null || type == null || outcome == null) return;
+
+        BlockPos target = pos == null ? BlockPos.ZERO : pos.immutable();
+        String dimension = level.dimension().location().toString();
+        String safeContext = context == null ? "" : context.trim();
+        if (safeContext.length() > MAX_CONTEXT_LENGTH) {
+            safeContext = safeContext.substring(0, MAX_CONTEXT_LENGTH);
+        }
+
+        synchronized (HISTORIES) {
+            History history = HISTORIES.computeIfAbsent(server,
+                    ignored -> new History());
+            long sequence = ++history.version;
+            history.entries.addFirst(new DecisionEntry(sequence, type, outcome,
+                    target, dimension, safeContext,
+                    (float) Math.max(0.0D, cost), server.getTickCount()));
+            while (history.entries.size() > MAX_HISTORY) {
+                history.entries.removeLast();
+            }
+        }
+    }
+
+    public static Snapshot snapshot(MinecraftServer server) {
+        if (server == null) return new Snapshot(0L, List.of());
+        synchronized (HISTORIES) {
+            History history = HISTORIES.computeIfAbsent(server,
+                    ignored -> new History());
+            long now = server.getTickCount();
+            history.entries.removeIf(entry ->
+                    now - entry.createdTick() >= CLIENT_LIFETIME_TICKS);
+            return new Snapshot(history.version,
+                    List.copyOf(new ArrayList<>(history.entries)));
+        }
+    }
+
+    public enum DecisionType {
+        OPEN_DOOR,
+        CLOSE_DOOR,
+        DENY_ACCESS,
+        TESLA_SUPPRESSION,
+        OPEN_SCP_012_ROUTE,
+        OPEN_SCP_012_BOX,
+        ABANDON_SCP_012_CONTEST,
+        ABORTED_ACTION
+    }
+
+    public enum DecisionOutcome {
+        EXECUTED,
+        ABANDONED,
+        ABORTED
+    }
+
+    public record DecisionEntry(long sequence, DecisionType type,
+            DecisionOutcome outcome, BlockPos pos, String dimension,
+            String context, float cost, long createdTick) {
+    }
+
+    public record Snapshot(long version, List<DecisionEntry> entries) {
+        public Snapshot {
+            entries = entries == null ? List.of() : List.copyOf(entries);
+        }
+    }
+
+    private static final class History {
+        private final Deque<DecisionEntry> entries = new ArrayDeque<>();
+        private long version;
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079FacilityThreatEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079FacilityThreatEvents.java
@@ -97,8 +97,6 @@ public final class Scp079FacilityThreatEvents {
             return;
         }
 
-        // Harassment without a real threat is intentionally rare, delayed and
-        // disallowed while SCP-079 is preserving processing for useful actions.
         if ((gameTime + player.getId()) % UNPROVOKED_INTERVAL_TICKS != 0L
                 || availablePower < 60.0F) {
             return;
@@ -109,7 +107,8 @@ public final class Scp079FacilityThreatEvents {
         if (ahead.open() != null
                 && level.getRandom().nextFloat() < UNPROVOKED_CLOSE_CHANCE) {
             execute(level, new Action(ActionType.CLOSE,
-                    ahead.open(), 40.0D, UNPROVOKED_COST, 0), gameTime);
+                    ahead.open(), 40.0D, UNPROVOKED_COST, 0), gameTime,
+                    player, null);
         }
     }
 
@@ -162,8 +161,6 @@ public final class Scp079FacilityThreatEvents {
                 level, action.cost()));
         if (candidates.isEmpty()) return;
 
-        // At low power SCP-079 rejects marginal harassment but can still spend
-        // its last cycles on a genuinely strong pursuit opportunity.
         Action selected = candidates.stream()
                 .max(Comparator.comparingDouble(action -> adjustedUtility(
                         action, availablePower)))
@@ -172,7 +169,7 @@ public final class Scp079FacilityThreatEvents {
                 || adjustedUtility(selected, availablePower) < 52.0D) {
             return;
         }
-        execute(level, selected, gameTime);
+        execute(level, selected, gameTime, player, pursuer);
     }
 
     private static double adjustedUtility(Action action, float availablePower) {
@@ -183,7 +180,7 @@ public final class Scp079FacilityThreatEvents {
     }
 
     private static boolean execute(ServerLevel level, Action action,
-            long gameTime) {
+            long gameTime, ServerPlayer player, Mob pursuer) {
         if (!Scp079ProcessingManager.trySpend(level, action.cost())) {
             return false;
         }
@@ -196,6 +193,11 @@ public final class Scp079FacilityThreatEvents {
         };
         if (!success) {
             Scp079ProcessingManager.refund(level, action.cost());
+            Scp079DecisionLog.record(level,
+                    Scp079DecisionLog.DecisionType.ABORTED_ACTION,
+                    Scp079DecisionLog.DecisionOutcome.ABORTED,
+                    action.door().pos(), 0.0D,
+                    "door state changed before execution · processing refunded");
             return false;
         }
 
@@ -203,7 +205,36 @@ public final class Scp079FacilityThreatEvents {
                 ? LOCKED_DOOR_REUSE_TICKS : DOOR_REUSE_TICKS;
         DOOR_COOLDOWNS.put(new DoorKey(level.dimension(),
                 action.door().pos().asLong()), gameTime + reuse);
+        Scp079DecisionLog.record(level, decisionType(action.type()),
+                Scp079DecisionLog.DecisionOutcome.EXECUTED,
+                action.door().pos(), action.cost(),
+                decisionContext(action, player, pursuer));
         return true;
+    }
+
+    private static Scp079DecisionLog.DecisionType decisionType(
+            ActionType type) {
+        return switch (type) {
+            case OPEN -> Scp079DecisionLog.DecisionType.OPEN_DOOR;
+            case CLOSE -> Scp079DecisionLog.DecisionType.CLOSE_DOOR;
+            case DENY -> Scp079DecisionLog.DecisionType.DENY_ACCESS;
+        };
+    }
+
+    private static String decisionContext(Action action,
+            ServerPlayer player, Mob pursuer) {
+        String playerName = player == null ? "player"
+                : player.getGameProfile().getName();
+        String threat = pursuer == null ? ""
+                : pursuer.getDisplayName().getString();
+        return switch (action.type()) {
+            case OPEN -> "for " + threat + " pursuing " + playerName;
+            case CLOSE -> pursuer == null
+                    ? "unprovoked near " + playerName
+                    : "ahead of " + playerName + " fleeing " + threat;
+            case DENY -> "against " + playerName + " fleeing " + threat
+                    + " · " + action.durationTicks() / 20.0D + "s";
+        };
     }
 
     private static AheadDoors findDoorsAhead(ServerLevel level,
@@ -236,8 +267,6 @@ public final class Scp079FacilityThreatEvents {
         double closedDistance = Double.MAX_VALUE;
         Set<Long> visited = new HashSet<>();
 
-        // Sample a narrow projected corridor instead of scanning a complete
-        // 15x6x15 cube every second during pursuit.
         for (int step = 1; step <= FLEE_DOOR_RADIUS; step++) {
             Vec3 sample = player.position().add(direction.scale(step));
             BlockPos center = BlockPos.containing(sample);
@@ -387,8 +416,6 @@ public final class Scp079FacilityThreatEvents {
                 level, match.pos());
         if (controlCount <= 0) return false;
 
-        // Do not visually close the connected panel while an unrelated lever or
-        // other ordinary redstone source is still forcing the door open.
         if (doorPowered(level, match.pos())) {
             HeavyDoorControlPanelAccess.openConnectedControls(level, match.pos());
             return false;
@@ -477,7 +504,7 @@ public final class Scp079FacilityThreatEvents {
     }
 
     private record Action(ActionType type, DoorMatch door, double utility,
-                          double cost, int durationTicks) {
+                           double cost, int durationTicks) {
     }
 
     private record AheadDoors(DoorMatch open, DoorMatch closed) {

--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079ProcessingManager.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079ProcessingManager.java
@@ -25,9 +25,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * Shared processing-power budget for SCP-079's facility decisions.
  *
  * The value is updated lazily whenever gameplay needs it, avoiding another
- * permanent server tick loop. Developer HUD synchronization is staggered and
- * sends a packet only when a rounded value, toggle, scheduled tick or result
- * actually changes; spawn countdown animation remains client-side.
+ * permanent server tick loop. Developer HUD synchronization is staggered. The
+ * decision feed uses a separate snapshot packet and is only resent when a
+ * meaningful decision changes its history.
  */
 @Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID,
         bus = Mod.EventBusSubscriber.Bus.FORGE)
@@ -126,14 +126,24 @@ public final class Scp079ProcessingManager {
                 ? Math.round(getPower(player.serverLevel())) : 0;
         List<RoamerDebugSnapshot> roamers = spawnTimersVisible
                 ? RoamerManager.debugSnapshots(player) : List.of();
+        Scp079DecisionLog.Snapshot decisionSnapshot = energyVisible
+                ? Scp079DecisionLog.snapshot(player.getServer())
+                : new Scp079DecisionLog.Snapshot(-1L, List.of());
 
         ClientSnapshot next = new ClientSnapshot(energyVisible, active,
-                roundedPower, spawnTimersVisible, roamers);
-        ClientSnapshot previous = LAST_CLIENT_SYNC.put(player.getUUID(), next);
-        if (!next.equals(previous)) {
+                roundedPower, spawnTimersVisible, roamers,
+                decisionSnapshot.version());
+        ClientSnapshot previous = LAST_CLIENT_SYNC.get(player.getUUID());
+
+        if (previous == null || !next.sameCoreState(previous)) {
             ScpEntityNetwork.syncDebugState(player, energyVisible, active,
                     roundedPower, spawnTimersVisible, roamers);
         }
+        if (energyVisible && (previous == null || !previous.energyVisible()
+                || previous.decisionVersion() != decisionSnapshot.version())) {
+            ScpEntityNetwork.syncScp079Decisions(player, decisionSnapshot);
+        }
+        LAST_CLIENT_SYNC.put(player.getUUID(), next);
     }
 
     @SubscribeEvent
@@ -170,9 +180,18 @@ public final class Scp079ProcessingManager {
 
     private record ClientSnapshot(boolean energyVisible, boolean active,
             int roundedPower, boolean spawnTimersVisible,
-            List<RoamerDebugSnapshot> roamers) {
+            List<RoamerDebugSnapshot> roamers, long decisionVersion) {
         private ClientSnapshot {
             roamers = roamers == null ? List.of() : List.copyOf(roamers);
+        }
+
+        private boolean sameCoreState(ClientSnapshot other) {
+            return other != null
+                    && energyVisible == other.energyVisible
+                    && active == other.active
+                    && roundedPower == other.roundedPower
+                    && spawnTimersVisible == other.spawnTimersVisible
+                    && roamers.equals(other.roamers);
         }
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079TeslaSuppression.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079TeslaSuppression.java
@@ -90,6 +90,19 @@ public final class Scp079TeslaSuppression {
         STATES.put(key, new GateState(suppressedUntil,
                 suppressedUntil + DEVICE_REUSE_TICKS, suppressedUntil));
         emitInterference(level, gatePos);
+
+        ServerPlayer target = pursuer.getTarget() instanceof ServerPlayer player
+                ? player : null;
+        String targetName = target == null ? "player"
+                : target.getGameProfile().getName();
+        String mode = manualOverride ? "Emergency Override"
+                : "normal circuit";
+        Scp079DecisionLog.record(level,
+                Scp079DecisionLog.DecisionType.TESLA_SUPPRESSION,
+                Scp079DecisionLog.DecisionOutcome.EXECUTED, gatePos, cost,
+                "for " + pursuer.getDisplayName().getString()
+                        + " pursuing " + targetName + " · " + mode
+                        + " · " + SUPPRESSION_TICKS / 20.0D + "s");
         return true;
     }
 

--- a/src/main/java/net/mcreator/scpadditions/network/Scp079DecisionPacket.java
+++ b/src/main/java/net/mcreator/scpadditions/network/Scp079DecisionPacket.java
@@ -1,0 +1,96 @@
+package net.mcreator.scpadditions.network;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.util.Mth;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+import net.mcreator.scpadditions.client.Scp079EnergyClientState;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog.DecisionOutcome;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog.DecisionType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/** Server-to-client snapshot of the event-driven SCP-079 decision feed. */
+public final class Scp079DecisionPacket {
+    private static final int MAX_ENTRIES = 12;
+    private static final int MAX_DIMENSION_LENGTH = 96;
+    private static final int MAX_CONTEXT_LENGTH = 160;
+
+    private final List<DecisionEntry> entries;
+
+    public Scp079DecisionPacket(List<DecisionEntry> entries) {
+        this.entries = entries == null ? List.of() : List.copyOf(entries);
+    }
+
+    public static void encode(Scp079DecisionPacket message,
+            FriendlyByteBuf buffer) {
+        int size = Math.min(MAX_ENTRIES, message.entries.size());
+        buffer.writeVarInt(size);
+        for (int index = 0; index < size; index++) {
+            DecisionEntry entry = message.entries.get(index);
+            buffer.writeVarLong(Math.max(0L, entry.sequence()));
+            buffer.writeVarInt(entry.type().ordinal());
+            buffer.writeVarInt(entry.outcome().ordinal());
+            buffer.writeBlockPos(entry.pos());
+            buffer.writeUtf(entry.dimension(), MAX_DIMENSION_LENGTH);
+            buffer.writeUtf(entry.context(), MAX_CONTEXT_LENGTH);
+            buffer.writeFloat(Math.max(0.0F, entry.cost()));
+            buffer.writeVarInt(Mth.clamp(entry.ageTicks(), 0,
+                    net.mcreator.scpadditions.facility.Scp079DecisionLog
+                            .CLIENT_LIFETIME_TICKS));
+        }
+    }
+
+    public static Scp079DecisionPacket decode(FriendlyByteBuf buffer) {
+        int size = Mth.clamp(buffer.readVarInt(), 0, MAX_ENTRIES);
+        List<DecisionEntry> entries = new ArrayList<>(size);
+        for (int index = 0; index < size; index++) {
+            long sequence = Math.max(0L, buffer.readVarLong());
+            DecisionType type = enumById(DecisionType.values(),
+                    buffer.readVarInt(), DecisionType.ABORTED_ACTION);
+            DecisionOutcome outcome = enumById(DecisionOutcome.values(),
+                    buffer.readVarInt(), DecisionOutcome.ABORTED);
+            BlockPos pos = buffer.readBlockPos();
+            String dimension = buffer.readUtf(MAX_DIMENSION_LENGTH);
+            String context = buffer.readUtf(MAX_CONTEXT_LENGTH);
+            float cost = Math.max(0.0F, buffer.readFloat());
+            int ageTicks = Mth.clamp(buffer.readVarInt(), 0,
+                    net.mcreator.scpadditions.facility.Scp079DecisionLog
+                            .CLIENT_LIFETIME_TICKS);
+            entries.add(new DecisionEntry(sequence, type, outcome, pos,
+                    dimension, context, cost, ageTicks));
+        }
+        return new Scp079DecisionPacket(entries);
+    }
+
+    public static void handle(Scp079DecisionPacket message,
+            Supplier<NetworkEvent.Context> supplier) {
+        NetworkEvent.Context context = supplier.get();
+        context.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
+                () -> () -> Scp079EnergyClientState.replaceDecisions(
+                        message.entries)));
+        context.setPacketHandled(true);
+    }
+
+    private static <T> T enumById(T[] values, int id, T fallback) {
+        return id >= 0 && id < values.length ? values[id] : fallback;
+    }
+
+    public record DecisionEntry(long sequence, DecisionType type,
+            DecisionOutcome outcome, BlockPos pos, String dimension,
+            String context, float cost, int ageTicks) {
+        public DecisionEntry {
+            if (type == null) type = DecisionType.ABORTED_ACTION;
+            if (outcome == null) outcome = DecisionOutcome.ABORTED;
+            if (pos == null) pos = BlockPos.ZERO;
+            if (dimension == null) dimension = "";
+            if (context == null) context = "";
+            cost = Math.max(0.0F, cost);
+            ageTicks = Math.max(0, ageTicks);
+        }
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/network/ScpEntityNetwork.java
+++ b/src/main/java/net/mcreator/scpadditions/network/ScpEntityNetwork.java
@@ -5,6 +5,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.PacketDistributor;
 import net.mcreator.scpadditions.ScpAdditionsMod;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog;
+import net.mcreator.scpadditions.network.Scp079DecisionPacket.DecisionEntry;
 import net.mcreator.scpadditions.network.Scp079EnergyPacket.RoamerEntry;
 import net.mcreator.scpadditions.roamer.RoamerDebugSnapshot;
 
@@ -85,6 +87,10 @@ public final class ScpEntityNetwork {
                 Scp079EnergyPacket::encode,
                 Scp079EnergyPacket::decode,
                 Scp079EnergyPacket::handle);
+        ScpAdditionsMod.addNetworkMessage(Scp079DecisionPacket.class,
+                Scp079DecisionPacket::encode,
+                Scp079DecisionPacket::decode,
+                Scp079DecisionPacket::handle);
     }
 
     public static void showScp131Notice(ServerPlayer player,
@@ -169,6 +175,23 @@ public final class ScpEntityNetwork {
                 PacketDistributor.PLAYER.with(() -> player),
                 new Scp079EnergyPacket(energyVisible, active, energy,
                         spawnTimersVisible, entries));
+    }
+
+    public static void syncScp079Decisions(ServerPlayer player,
+            Scp079DecisionLog.Snapshot snapshot) {
+        if (player == null || snapshot == null) return;
+        MinecraftServer server = player.getServer();
+        long currentTick = server == null ? 0L : server.getTickCount();
+        List<DecisionEntry> entries = new ArrayList<>();
+        for (Scp079DecisionLog.DecisionEntry entry : snapshot.entries()) {
+            entries.add(new DecisionEntry(entry.sequence(), entry.type(),
+                    entry.outcome(), entry.pos(), entry.dimension(),
+                    entry.context(), entry.cost(), (int) Math.max(0L,
+                    currentTick - entry.createdTick())));
+        }
+        ScpAdditionsMod.PACKET_HANDLER.send(
+                PacketDistributor.PLAYER.with(() -> player),
+                new Scp079DecisionPacket(entries));
     }
 
     public static void playScare(ServerPlayer player) {

--- a/src/main/java/net/mcreator/scpadditions/scp012/Scp012DoorAccess.java
+++ b/src/main/java/net/mcreator/scpadditions/scp012/Scp012DoorAccess.java
@@ -15,6 +15,7 @@ import net.minecraft.world.phys.Vec3;
 import net.mcreator.scpadditions.effect.Scp714ProtectionAccess;
 import net.mcreator.scpadditions.facility.FacilityModule;
 import net.mcreator.scpadditions.facility.HeavyDoorControlPanelAccess;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog;
 import net.mcreator.scpadditions.facility.Scp079ProcessingManager;
 
 import java.util.HashSet;
@@ -47,10 +48,6 @@ public final class Scp012DoorAccess {
         return tryOpen(level, player, scpPos, 0.0D);
     }
 
-    /**
-     * @param reservedPower processing that must remain available for the box
-     *                      opening or another action in the same trap sequence
-     */
     public static boolean tryOpen(ServerLevel level, ServerPlayer player,
                                    BlockPos scpPos, double reservedPower) {
         Vec3 playerPosition = player.position();
@@ -74,8 +71,6 @@ public final class Scp012DoorAccess {
                 Math.max(1, (int) Math.ceil(horizontalRoute.length())));
         Set<Long> visited = new HashSet<>();
 
-        // Probe only the narrow route toward SCP-012. The previous full
-        // 11x6x11 cube was unnecessary during the twice-per-second trap check.
         for (int step = 1; step <= routeSteps; step++) {
             Vec3 sample = playerPosition.add(routeDirection.scale(step));
             BlockPos sampleCenter = BlockPos.containing(sample);
@@ -114,18 +109,24 @@ public final class Scp012DoorAccess {
                             continue;
                         }
 
-                        int attempts = activeContest
-                                ? contest.attempts() : 0;
+                        int attempts = activeContest ? contest.attempts() : 0;
                         double cost = attemptCost(attempts);
                         if (!Scp079ProcessingManager.canAfford(level,
                                 cost + reservedPower)) {
-                            if (activeContest) abandon(key, time);
+                            if (activeContest) {
+                                abandon(level, key, pos, time, player,
+                                        "insufficient processing for the next attempt");
+                            }
                             continue;
                         }
-                        if (activeContest && !worthContinuing(level, player,
-                                scpPos, contest, cost)) {
-                            abandon(key, time);
-                            continue;
+                        if (activeContest) {
+                            String rejection = continuationRejection(level,
+                                    player, scpPos, contest, cost);
+                            if (rejection != null) {
+                                abandon(level, key, pos, time, player,
+                                        rejection);
+                                continue;
+                            }
                         }
 
                         double distance = player.distanceToSqr(
@@ -140,9 +141,7 @@ public final class Scp012DoorAccess {
         }
 
         if (best == null) return false;
-        if (!Scp079ProcessingManager.trySpend(level, best.cost())) {
-            return false;
-        }
+        if (!Scp079ProcessingManager.trySpend(level, best.cost())) return false;
 
         BlockState current = level.getBlockState(best.match().pos());
         if (current.getBlock() != best.match().family().closed().get()
@@ -150,6 +149,11 @@ public final class Scp012DoorAccess {
                 || HeavyDoorControlPanelAccess.openConnectedControls(level,
                 best.match().pos()) <= 0) {
             Scp079ProcessingManager.refund(level, best.cost());
+            Scp079DecisionLog.record(level,
+                    Scp079DecisionLog.DecisionType.ABORTED_ACTION,
+                    Scp079DecisionLog.DecisionOutcome.ABORTED,
+                    best.match().pos(), 0.0D,
+                    "SCP-012 route changed before override · processing refunded");
             return false;
         }
 
@@ -169,17 +173,23 @@ public final class Scp012DoorAccess {
                 + (previous == null ? 0.0D : previous.processingSpent());
         CONTESTS.put(best.key(), new ContestState(player.getUUID(), attempts,
                 spent, time + CONTEST_MEMORY_TICKS));
+        Scp079DecisionLog.record(level,
+                Scp079DecisionLog.DecisionType.OPEN_SCP_012_ROUTE,
+                Scp079DecisionLog.DecisionOutcome.EXECUTED,
+                best.match().pos(), best.cost(),
+                "attempt " + attempts + " for "
+                        + player.getGameProfile().getName()
+                        + " · contest total " + Math.round(spent) + " AP");
         return true;
     }
 
-    private static boolean worthContinuing(ServerLevel level,
+    private static String continuationRejection(ServerLevel level,
             ServerPlayer player, BlockPos scpPos, ContestState contest,
             double nextCost) {
         boolean protectedBy714 = Scp714ProtectionAccess.isProtected(player);
-
-        // The first re-open remains a plausible precaution against SCP-714, but
-        // repeatedly fighting a protected player is recognized as wasteful.
-        if (protectedBy714 && contest.attempts() >= 2) return false;
+        if (protectedBy714 && contest.attempts() >= 2) {
+            return "SCP-714 made further contention wasteful";
+        }
 
         double distance = player.position().distanceTo(
                 Scp012Module.attractionPoint(level, scpPos));
@@ -189,7 +199,8 @@ public final class Scp012DoorAccess {
         if (Scp079ProcessingManager.getPower(level) < 30.0F) utility -= 10.0D;
         utility -= nextCost * 0.35D;
         utility -= contest.processingSpent() * 0.12D;
-        return utility >= 20.0D;
+        return utility >= 20.0D ? null
+                : "expected utility fell below the processing cost";
     }
 
     private static double attemptCost(int completedAttempts) {
@@ -197,9 +208,14 @@ public final class Scp012DoorAccess {
         return ATTEMPT_COSTS[index];
     }
 
-    private static void abandon(DoorKey key, long time) {
+    private static void abandon(ServerLevel level, DoorKey key,
+            BlockPos pos, long time, ServerPlayer player, String reason) {
         CONTESTS.remove(key);
         COOLDOWNS.put(key, time + ABANDONED_DEVICE_COOLDOWN_TICKS);
+        Scp079DecisionLog.record(level,
+                Scp079DecisionLog.DecisionType.ABANDON_SCP_012_CONTEST,
+                Scp079DecisionLog.DecisionOutcome.ABANDONED, pos, 0.0D,
+                reason + " · " + player.getGameProfile().getName());
     }
 
     private static void clean(ServerLevel level, long time) {
@@ -224,9 +240,7 @@ public final class Scp012DoorAccess {
     private static boolean liesOnRoute(BlockState state, BlockPos doorPos,
                                         Vec3 playerPosition,
                                         Vec3 targetPosition) {
-        if (!state.hasProperty(HorizontalDirectionalBlock.FACING)) {
-            return false;
-        }
+        if (!state.hasProperty(HorizontalDirectionalBlock.FACING)) return false;
 
         Vec3 route = targetPosition.subtract(playerPosition);
         double routeLengthSqr = route.lengthSqr();

--- a/src/main/java/net/mcreator/scpadditions/scp012/Scp012InfluenceEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/scp012/Scp012InfluenceEvents.java
@@ -18,6 +18,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.mcreator.scpadditions.ScpAdditionsMod;
 import net.mcreator.scpadditions.effect.Scp714ProtectionAccess;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog;
 import net.mcreator.scpadditions.facility.Scp079ProcessingManager;
 import net.mcreator.scpadditions.init.ScpAdditionsModGameRules;
 import net.mcreator.scpadditions.init.ScpAdditionsModMobEffects;
@@ -41,8 +42,7 @@ public final class Scp012InfluenceEvents {
 
     private static final Map<UUID, ContactState> CONTACT_STATES = new HashMap<>();
     private static final Map<UUID, BlockPos> ACTIVE_TARGETS = new HashMap<>();
-    private static final Map<UUID, DiscoveredTarget> DISCOVERED_TARGETS =
-            new HashMap<>();
+    private static final Map<UUID, DiscoveredTarget> DISCOVERED_TARGETS = new HashMap<>();
     private static final Map<UUID, Long> NEXT_TARGET_SEARCH = new HashMap<>();
 
     private Scp012InfluenceEvents() {
@@ -51,9 +51,7 @@ public final class Scp012InfluenceEvents {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
         if (event.phase != TickEvent.Phase.END
-                || !(event.player instanceof ServerPlayer player)) {
-            return;
-        }
+                || !(event.player instanceof ServerPlayer player)) return;
         if (!player.isAlive() || player.isCreative() || player.isSpectator()) {
             clearAll(player);
             return;
@@ -71,10 +69,6 @@ public final class Scp012InfluenceEvents {
         Vec3 attraction = Scp012Module.attractionPoint(level, nearby);
         double distance = player.position().distanceTo(attraction);
 
-        // SCP-079 still attempts the physical trap against SCP-714 as a
-        // precaution, but both the route and box now compete for its shared
-        // processing budget. Re-opening a contested route is evaluated by
-        // Scp012DoorAccess instead of happening as a free mechanical loop.
         if (systemControl) {
             Scp012Stage stage = Scp012Module.stageOf(level.getBlockState(nearby));
             boolean boxClosed = stage == Scp012Stage.CLOSED;
@@ -86,12 +80,23 @@ public final class Scp012InfluenceEvents {
             }
             if (boxClosed && Scp079ProcessingManager.trySpend(level,
                     SCP_012_BOX_OPEN_COST)) {
-                Scp012Module.open(level, nearby);
+                if (Scp012Module.open(level, nearby)) {
+                    String protection = Scp714ProtectionAccess.isProtected(player)
+                            ? " · SCP-714 detected" : "";
+                    Scp079DecisionLog.record(level,
+                            Scp079DecisionLog.DecisionType.OPEN_SCP_012_BOX,
+                            Scp079DecisionLog.DecisionOutcome.EXECUTED,
+                            nearby, SCP_012_BOX_OPEN_COST,
+                            "precautionary trap for "
+                                    + player.getGameProfile().getName()
+                                    + protection);
+                } else {
+                    Scp079ProcessingManager.refund(level,
+                            SCP_012_BOX_OPEN_COST);
+                }
             }
         }
 
-        // SCP-714 cancels only SCP-012's anomalous influence. It deliberately
-        // does not close the box, undo SCP-079's door actions, or cure bleeding.
         if (Scp714ProtectionAccess.isProtected(player)) {
             clearInfluence(player);
             return;
@@ -135,14 +140,9 @@ public final class Scp012InfluenceEvents {
         DISCOVERED_TARGETS.remove(id);
 
         long gameTime = level.getGameTime();
-        if (NEXT_TARGET_SEARCH.getOrDefault(id, 0L) > gameTime) {
-            return null;
-        }
+        if (NEXT_TARGET_SEARCH.getOrDefault(id, 0L) > gameTime) return null;
         NEXT_TARGET_SEARCH.put(id, gameTime + TARGET_SEARCH_INTERVAL_TICKS);
 
-        // Discover the box slightly before the player reaches its actual effect
-        // radius. The cached target can then trigger on the exact crossing tick
-        // without restoring the old full-cube scan on every player tick.
         BlockPos found = Scp012Module.findNearest(level, player.position(),
                 TARGET_DISCOVERY_RADIUS, false);
         if (found == null) return null;
@@ -214,9 +214,7 @@ public final class Scp012InfluenceEvents {
                         "You tear open your left wrist and start writing "
                                 + "on the composition with your blood."), true);
             }
-            if (state.damageTaken >= maxHealth * 0.40F) {
-                applyBleeding(player);
-            }
+            if (state.damageTaken >= maxHealth * 0.40F) applyBleeding(player);
         }
 
         return Mth.clamp(state.ticks / (float) FATAL_CONTACT_TICKS,

--- a/src/main/java/net/mcreator/scpadditions/vitals/client/Scp079EnergyOverlay.java
+++ b/src/main/java/net/mcreator/scpadditions/vitals/client/Scp079EnergyOverlay.java
@@ -1,28 +1,52 @@
 package net.mcreator.scpadditions.vitals.client;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.mcreator.scpadditions.client.Scp079EnergyClientState;
+import net.mcreator.scpadditions.client.Scp079EnergyClientState.ClientDecisionSnapshot;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog.DecisionOutcome;
+import net.mcreator.scpadditions.facility.Scp079DecisionLog.DecisionType;
 import net.mcreator.scpadditions.init.ScpAdditionsModItems;
 
-/** White upper-right developer HUD for SCP-079 processing power. */
+import java.util.List;
+import java.util.Locale;
+
+/** White upper-right developer HUD for SCP-079 processing and decisions. */
 public final class Scp079EnergyOverlay {
     private static final ResourceLocation ROBOTO_FONT =
             new ResourceLocation("scpinventory", "roboto");
 
-    private static final int WIDTH = 94;
-    private static final int HEIGHT = 32;
+    private static final int ENERGY_WIDTH = 94;
+    private static final int ENERGY_HEIGHT = 32;
+    private static final int FEED_WIDTH = 238;
+    private static final int FEED_HEADER_HEIGHT = 16;
+    private static final int ENTRY_HEIGHT = 27;
+    private static final int MAX_VISIBLE_ENTRIES = 5;
+    private static final int GAP = 5;
     private static final int MARGIN = 10;
     private static final int PANEL = 0xA8121518;
     private static final int PANEL_INACTIVE = 0x88121518;
+    private static final int ENTRY_PANEL = 0xB0121518;
     private static final int WHITE = 0xFFF4F4F4;
     private static final int MUTED = 0xFFB8B8B8;
     private static final int TRACK = 0x773C4145;
+    private static final int AMBER = 0xFFFFC56D;
+    private static final int RED = 0xFFFF8B8B;
+    private static final int FADE_START_TICKS = 220;
 
     private Scp079EnergyOverlay() {
+    }
+
+    public static int occupiedHeight() {
+        if (!Scp079EnergyClientState.visible()) return 0;
+        int rows = Math.max(1, Math.min(MAX_VISIBLE_ENTRIES,
+                Scp079EnergyClientState.decisions().size()));
+        return ENERGY_HEIGHT + GAP + FEED_HEADER_HEIGHT + rows * ENTRY_HEIGHT;
     }
 
     public static void render(GuiGraphics graphics, int screenWidth,
@@ -35,40 +59,195 @@ public final class Scp079EnergyOverlay {
             return;
         }
 
+        renderEnergy(graphics, minecraft, screenWidth);
+        renderDecisionFeed(graphics, minecraft, screenWidth);
+    }
+
+    private static void renderEnergy(GuiGraphics graphics,
+            Minecraft minecraft, int screenWidth) {
         boolean active = Scp079EnergyClientState.active();
         float energy = Math.max(0.0F,
                 Math.min(100.0F, Scp079EnergyClientState.energy()));
-        int x = screenWidth - WIDTH - MARGIN;
+        int x = screenWidth - ENERGY_WIDTH - MARGIN;
         int y = MARGIN;
 
-        graphics.fill(x, y, x + WIDTH, y + HEIGHT,
+        graphics.fill(x, y, x + ENERGY_WIDTH, y + ENERGY_HEIGHT,
                 active ? PANEL : PANEL_INACTIVE);
-        graphics.fill(x, y, x + WIDTH, y + 1, WHITE);
-        graphics.fill(x, y + HEIGHT - 1, x + WIDTH, y + HEIGHT, WHITE);
-        graphics.fill(x, y, x + 1, y + HEIGHT, WHITE);
-        graphics.fill(x + WIDTH - 1, y, x + WIDTH, y + HEIGHT, WHITE);
+        border(graphics, x, y, ENERGY_WIDTH, ENERGY_HEIGHT, WHITE);
 
         ItemStack icon = new ItemStack(ScpAdditionsModItems.SCP_079ON.get());
         graphics.renderItem(icon, x + 6, y + 6);
 
-        Component label = Component.literal(active ? "PROCESSING" : "OFFLINE")
-                .withStyle(style -> style.withFont(ROBOTO_FONT));
-        graphics.drawString(minecraft.font, label, x + 28, y + 5,
-                active ? WHITE : MUTED, false);
-
-        Component value = Component.literal(Integer.toString(Math.round(energy)))
-                .withStyle(style -> style.withFont(ROBOTO_FONT));
-        graphics.drawString(minecraft.font, value, x + 28, y + 15,
-                WHITE, false);
+        draw(graphics, minecraft.font, active ? "PROCESSING" : "OFFLINE",
+                x + 28, y + 5, active ? WHITE : MUTED);
+        draw(graphics, minecraft.font, Integer.toString(Math.round(energy)),
+                x + 28, y + 15, WHITE);
 
         int barX = x + 51;
         int barY = y + 18;
-        int barWidth = WIDTH - 57;
+        int barWidth = ENERGY_WIDTH - 57;
         graphics.fill(barX, barY, barX + barWidth, barY + 3, TRACK);
         int fill = Math.round(barWidth * energy / 100.0F);
         if (fill > 0) {
             graphics.fill(barX, barY, barX + fill, barY + 3,
                     active ? WHITE : MUTED);
         }
+    }
+
+    private static void renderDecisionFeed(GuiGraphics graphics,
+            Minecraft minecraft, int screenWidth) {
+        List<ClientDecisionSnapshot> decisions =
+                Scp079EnergyClientState.decisions();
+        int visible = Math.min(MAX_VISIBLE_ENTRIES, decisions.size());
+        int rows = Math.max(1, visible);
+        int height = FEED_HEADER_HEIGHT + rows * ENTRY_HEIGHT;
+        int x = screenWidth - FEED_WIDTH - MARGIN;
+        int y = MARGIN + ENERGY_HEIGHT + GAP;
+
+        graphics.fill(x, y, x + FEED_WIDTH, y + height, PANEL);
+        border(graphics, x, y, FEED_WIDTH, height, WHITE);
+        draw(graphics, minecraft.font, "SCP-079 DECISION LOG", x + 7,
+                y + 5, WHITE);
+
+        if (visible == 0) {
+            int rowY = y + FEED_HEADER_HEIGHT;
+            graphics.fill(x + 1, rowY, x + FEED_WIDTH - 1,
+                    rowY + ENTRY_HEIGHT - 1, ENTRY_PANEL);
+            draw(graphics, minecraft.font, "NO RECENT DECISIONS", x + 8,
+                    rowY + 9, MUTED);
+            return;
+        }
+
+        for (int index = 0; index < visible; index++) {
+            renderDecision(graphics, minecraft, decisions.get(index), x,
+                    y + FEED_HEADER_HEIGHT + index * ENTRY_HEIGHT);
+        }
+    }
+
+    private static void renderDecision(GuiGraphics graphics,
+            Minecraft minecraft, ClientDecisionSnapshot decision,
+            int x, int y) {
+        float alpha = fadeAlpha(decision.ageTicks());
+        int panel = withAlpha(ENTRY_PANEL, alpha);
+        int text = withAlpha(WHITE, alpha);
+        int muted = withAlpha(MUTED, alpha);
+        int stripe = withAlpha(outcomeColor(decision.outcome()), alpha);
+
+        graphics.fill(x + 1, y, x + FEED_WIDTH - 1,
+                y + ENTRY_HEIGHT - 1, panel);
+        graphics.fill(x + 1, y, x + 4, y + ENTRY_HEIGHT - 1, stripe);
+
+        String cost = decision.cost() > 0.01F
+                ? "-" + formatCost(decision.cost()) + " AP" : "";
+        int costWidth = cost.isEmpty() ? 0
+                : minecraft.font.width(styled(cost));
+        int titleWidth = FEED_WIDTH - 18 - costWidth;
+        String title = fit(minecraft.font, title(decision.type()), titleWidth);
+        draw(graphics, minecraft.font, title, x + 8, y + 5, text);
+        if (!cost.isEmpty()) {
+            draw(graphics, minecraft.font, cost,
+                    x + FEED_WIDTH - 7 - costWidth, y + 5, text);
+        }
+
+        String detail = detail(minecraft, decision);
+        draw(graphics, minecraft.font,
+                fit(minecraft.font, detail, FEED_WIDTH - 15),
+                x + 8, y + 16, muted);
+    }
+
+    private static String detail(Minecraft minecraft,
+            ClientDecisionSnapshot decision) {
+        StringBuilder result = new StringBuilder();
+        if (!decision.context().isBlank()) result.append(decision.context());
+        if (result.length() > 0) result.append(" · ");
+        if (minecraft.level != null && !decision.dimension().isBlank()
+                && !minecraft.level.dimension().location().toString()
+                .equals(decision.dimension())) {
+            result.append(shortDimension(decision.dimension())).append(' ');
+        }
+        result.append(decision.pos().getX()).append(' ')
+                .append(decision.pos().getY()).append(' ')
+                .append(decision.pos().getZ());
+        return result.toString();
+    }
+
+    private static String shortDimension(String dimension) {
+        int colon = dimension.indexOf(':');
+        return colon >= 0 && colon + 1 < dimension.length()
+                ? dimension.substring(colon + 1) : dimension;
+    }
+
+    private static String title(DecisionType type) {
+        return switch (type) {
+            case OPEN_DOOR -> "OPENED DOOR";
+            case CLOSE_DOOR -> "CLOSED DOOR";
+            case DENY_ACCESS -> "DENIED ACCESS";
+            case TESLA_SUPPRESSION -> "SUPPRESSED TESLA GATE";
+            case OPEN_SCP_012_ROUTE -> "OPENED SCP-012 ROUTE";
+            case OPEN_SCP_012_BOX -> "OPENED SCP-012";
+            case ABANDON_SCP_012_CONTEST ->
+                    "ABANDONED SCP-012 CONTEST";
+            case ABORTED_ACTION -> "ABORTED ACTION";
+        };
+    }
+
+    private static int outcomeColor(DecisionOutcome outcome) {
+        return switch (outcome) {
+            case EXECUTED -> WHITE;
+            case ABANDONED -> AMBER;
+            case ABORTED -> RED;
+        };
+    }
+
+    private static float fadeAlpha(int ageTicks) {
+        if (ageTicks <= FADE_START_TICKS) return 1.0F;
+        int fadeDuration = Math.max(1,
+                Scp079DecisionLog.CLIENT_LIFETIME_TICKS - FADE_START_TICKS);
+        return Math.max(0.0F, 1.0F
+                - (ageTicks - FADE_START_TICKS) / (float) fadeDuration);
+    }
+
+    private static String formatCost(float cost) {
+        if (Math.abs(cost - Math.round(cost)) < 0.05F) {
+            return Integer.toString(Math.round(cost));
+        }
+        return String.format(Locale.ROOT, "%.1f", cost);
+    }
+
+    private static String fit(Font font, String text, int maxWidth) {
+        if (text == null || text.isBlank() || maxWidth <= 0) return "";
+        if (font.width(styled(text)) <= maxWidth) return text;
+        String suffix = "...";
+        int end = text.length();
+        while (end > 0 && font.width(styled(
+                text.substring(0, end) + suffix)) > maxWidth) {
+            end--;
+        }
+        return end <= 0 ? suffix : text.substring(0, end) + suffix;
+    }
+
+    private static void draw(GuiGraphics graphics, Font font, String text,
+            int x, int y, int color) {
+        graphics.drawString(font, styled(text), x, y, color, false);
+    }
+
+    private static Component styled(String text) {
+        return Component.literal(text == null ? "" : text)
+                .withStyle(style -> style.withFont(ROBOTO_FONT));
+    }
+
+    private static int withAlpha(int color, float multiplier) {
+        int alpha = (color >>> 24) & 0xFF;
+        int adjusted = Math.max(0, Math.min(255,
+                Math.round(alpha * multiplier)));
+        return (adjusted << 24) | (color & 0x00FFFFFF);
+    }
+
+    private static void border(GuiGraphics graphics, int x, int y,
+            int width, int height, int color) {
+        graphics.fill(x, y, x + width, y + 1, color);
+        graphics.fill(x, y + height - 1, x + width, y + height, color);
+        graphics.fill(x, y, x + 1, y + height, color);
+        graphics.fill(x + width - 1, y, x + width, y + height, color);
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/vitals/client/ScpSpawnTimersOverlay.java
+++ b/src/main/java/net/mcreator/scpadditions/vitals/client/ScpSpawnTimersOverlay.java
@@ -38,7 +38,8 @@ public final class ScpSpawnTimersOverlay {
         }
 
         int x = screenWidth - WIDTH - MARGIN;
-        int y = MARGIN + (Scp079EnergyClientState.visible() ? 38 : 0);
+        int y = MARGIN + Scp079EnergyOverlay.occupiedHeight()
+                + (Scp079EnergyClientState.visible() ? 6 : 0);
         graphics.fill(x, y, x + WIDTH, y + HEIGHT, PANEL);
         border(graphics, x, y, WIDTH, HEIGHT);
         draw(graphics, minecraft, "ROAMER SPAWN SCHEDULER", x + 7,


### PR DESCRIPTION
## Summary
- adds a newest-first, fading decision feed beneath the existing SCP-079 processing HUD
- records only meaningful executed actions, strategic SCP-012 abandonments, and post-selection failures that refund processing
- includes action type, processing cost, context, coordinates, and cross-dimension identification
- synchronizes decision history separately from energy so strings are sent only when history changes
- keeps the roamer scheduler HUD below the variable-height SCP-079 panel
- instruments facility doors, temporary access denial, Tesla suppression, SCP-012 route contention, and SCP-012 box opening
- is based on the latest master, preserving the concurrent SCP-106 corrosion and movement work

Routine checks that select no action are intentionally omitted to keep the feed useful rather than noisy.