### PR TITLE
Trigger SCP-106 changelog cleanup

### DIFF
--- a/.github/scp106-pr-trigger
+++ b/.github/scp106-pr-trigger
@@ -1,0 +1,1 @@
+trigger

--- a/.github/scp106-pr-trigger
+++ b/.github/scp106-pr-trigger
@@ -1,1 +1,1 @@
-trigger
+trigger synchronized cleanup


### PR DESCRIPTION
Temporary PR used only to trigger the final changelog cleanup workflow after merging SCP-106. It should not be merged.