### PR TITLE
Run SCP-106 changelog cleanup

### DIFF
--- a/.github/scp106-pr-trigger-v3
+++ b/.github/scp106-pr-trigger-v3
@@ -1,0 +1,1 @@
+trigger


### PR DESCRIPTION
Temporary PR used only to run the final changelog cleanup workflow after merging SCP-106. Do not merge.