### PR TITLE
Persist SCP-079 processing power across world reloads

### DIFF
--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079ProcessingManager.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079ProcessingManager.java
@@ -6,6 +6,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.server.ServerStoppedEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.mcreator.scpadditions.ScpAdditionsMod;
@@ -24,10 +26,11 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Shared processing-power budget for SCP-079's facility decisions.
  *
- * The value is updated lazily whenever gameplay needs it, avoiding another
- * permanent server tick loop. Developer HUD synchronization is staggered. The
- * decision feed uses a separate snapshot packet and is only resent when a
- * meaningful decision changes its history.
+ * The power value is stored in the world's SavedData. Regeneration remains
+ * lazy, so no permanent server tick loop is needed, and restarting the world
+ * neither resets the budget nor grants offline regeneration. Developer HUD
+ * synchronization is staggered. The decision feed uses a separate snapshot
+ * packet and is only resent when a meaningful decision changes its history.
  */
 @Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID,
         bus = Mod.EventBusSubscriber.Bus.FORGE)
@@ -76,7 +79,7 @@ public final class Scp079ProcessingManager {
             State state = state(server, isActive(level));
             state.active = isActive(level);
             update(server, state);
-            return (float) state.power;
+            return (float) state.data.power();
         }
     }
 
@@ -91,8 +94,9 @@ public final class Scp079ProcessingManager {
             State state = state(server, true);
             state.active = true;
             update(server, state);
-            if (state.power + 0.0001D < cost) return false;
-            state.power = Math.max(0.0D, state.power - cost);
+            double power = state.data.power();
+            if (power + 0.0001D < cost) return false;
+            state.data.setPower(power - cost);
             return true;
         }
     }
@@ -105,7 +109,7 @@ public final class Scp079ProcessingManager {
             State state = state(server, isActive(level));
             state.active = isActive(level);
             update(server, state);
-            state.power = Math.min(MAX_POWER, state.power + amount);
+            state.data.setPower(state.data.power() + amount);
         }
     }
 
@@ -161,28 +165,48 @@ public final class Scp079ProcessingManager {
         LAST_CLIENT_SYNC.remove(event.getEntity().getUUID());
     }
 
+    /** Capture any lazily accrued power before the world's final save. */
+    @SubscribeEvent
+    public static void onServerStopping(ServerStoppingEvent event) {
+        MinecraftServer server = event.getServer();
+        synchronized (STATES) {
+            State state = STATES.get(server);
+            if (state != null) update(server, state);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerStopped(ServerStoppedEvent event) {
+        synchronized (STATES) {
+            STATES.remove(event.getServer());
+        }
+        LAST_CLIENT_SYNC.clear();
+    }
+
     private static State state(MinecraftServer server, boolean active) {
         return STATES.computeIfAbsent(server,
-                ignored -> new State(INITIAL_POWER, server.getTickCount(), active));
+                ignored -> new State(Scp079ProcessingSavedData.get(server),
+                        server.getTickCount(), active));
     }
 
     private static void update(MinecraftServer server, State state) {
         long now = server.getTickCount();
         long elapsed = Math.max(0L, now - state.lastTick);
         if (state.active && elapsed > 0L) {
-            state.power = Math.min(MAX_POWER,
-                    state.power + elapsed * REGEN_PER_TICK);
+            state.data.setPower(state.data.power()
+                    + elapsed * REGEN_PER_TICK);
         }
         state.lastTick = now;
     }
 
     private static final class State {
-        private double power;
+        private final Scp079ProcessingSavedData data;
         private long lastTick;
         private boolean active;
 
-        private State(double power, long lastTick, boolean active) {
-            this.power = power;
+        private State(Scp079ProcessingSavedData data, long lastTick,
+                boolean active) {
+            this.data = data;
             this.lastTick = lastTick;
             this.active = active;
         }

--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079ProcessingSavedData.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079ProcessingSavedData.java
@@ -1,0 +1,58 @@
+package net.mcreator.scpadditions.facility;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.saveddata.SavedData;
+
+/** Persistent world storage for SCP-079's shared processing-power budget. */
+final class Scp079ProcessingSavedData extends SavedData {
+    private static final String DATA_NAME =
+            "scp_additions_scp079_processing";
+    private static final String POWER_TAG = "ProcessingPower";
+
+    private double power = Scp079ProcessingManager.INITIAL_POWER;
+
+    private Scp079ProcessingSavedData() {
+    }
+
+    static Scp079ProcessingSavedData get(MinecraftServer server) {
+        return server.overworld().getDataStorage().computeIfAbsent(
+                Scp079ProcessingSavedData::load,
+                Scp079ProcessingSavedData::new,
+                DATA_NAME);
+    }
+
+    private static Scp079ProcessingSavedData load(CompoundTag tag) {
+        Scp079ProcessingSavedData data = new Scp079ProcessingSavedData();
+        if (tag.contains(POWER_TAG, Tag.TAG_ANY_NUMERIC)) {
+            data.power = clamp(tag.getDouble(POWER_TAG));
+        }
+        return data;
+    }
+
+    double power() {
+        return power;
+    }
+
+    void setPower(double value) {
+        double clamped = clamp(value);
+        if (Math.abs(clamped - power) < 0.000001D) return;
+        power = clamped;
+        setDirty();
+    }
+
+    @Override
+    public CompoundTag save(CompoundTag tag) {
+        tag.putDouble(POWER_TAG, power);
+        return tag;
+    }
+
+    private static double clamp(double value) {
+        if (!Double.isFinite(value)) {
+            return Scp079ProcessingManager.INITIAL_POWER;
+        }
+        return Math.max(0.0D,
+                Math.min(Scp079ProcessingManager.MAX_POWER, value));
+    }
+}


### PR DESCRIPTION
## Summary
- stores SCP-079's shared processing power in persistent world SavedData
- preserves the exact budget when leaving and reopening a world
- keeps the existing 25 AP first-time default, 100 AP maximum, and 0.5 AP/s regeneration
- does not grant regeneration while the world is closed
- flushes any lazily accrued power before the integrated server's final save
- leaves the one-second decision evaluation cadence unchanged after review, because the apparent delay is more likely caused by pursuer targeting/pathfinding and door geometry than the scheduler itself

Existing worlds will begin persisting the value after this update. The first load after upgrading has no previous SavedData value to recover, so it uses the normal 25 AP default once; subsequent reloads preserve the current amount.