### PR TITLE
Fix Blink module enforcement and SCP-914 recipe conflicts

### DIFF
--- a/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeBridge.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeBridge.java
@@ -13,8 +13,9 @@ import java.util.Optional;
 
 /**
  * Selects between explicit JSON recipes and inferred crafting behavior.
- * Explicit definitions are always authoritative; inferred recipes are only a
- * fallback when no configured recipe matches the selected setting and intake.
+ * Explicit definitions win equal matches, while a more complete inferred
+ * crafting recipe may take priority over an explicit recipe that accounts for
+ * only a small part of the intake.
  */
 public final class Scp914RecipeBridge {
     private Scp914RecipeBridge() {
@@ -25,17 +26,20 @@ public final class Scp914RecipeBridge {
             Scp914RecipeManager.Setting setting,
             List<ItemEntity> itemEntities,
             List<Entity> entities) {
-        Optional<Scp914RecipeManager.RecipeMatch> selected = selectForSetting(
-                level, setting, itemEntities, entities);
+        Optional<Scp914RecipeManager.RecipeMatch> selected =
+                selectForSetting(level, setting, itemEntities, entities);
 
         // Very Fine may reuse a valid Fine transformation only when no explicit
         // or inferred Very Fine transformation exists.
-        if (selected.isEmpty() && setting == Scp914RecipeManager.Setting.VERY_FINE) {
-            selected = selectForSetting(level, Scp914RecipeManager.Setting.FINE,
+        if (selected.isEmpty()
+                && setting == Scp914RecipeManager.Setting.VERY_FINE) {
+            selected = selectForSetting(level,
+                    Scp914RecipeManager.Setting.FINE,
                     itemEntities, entities);
         }
 
-        return selected.map(match -> consumeCompleteIntake(match, itemEntities));
+        return selected.map(match -> consumeCompleteIntake(match,
+                itemEntities));
     }
 
     private static Optional<Scp914RecipeManager.RecipeMatch> selectForSetting(
@@ -45,15 +49,34 @@ public final class Scp914RecipeBridge {
             List<Entity> entities) {
         Optional<Scp914RecipeManager.RecipeMatch> explicit =
                 Scp914RecipeManager.findRecipe(setting, itemEntities, entities);
-        if (explicit.isPresent()) {
-            return explicit;
-        }
 
-        if (entities != null && !entities.isEmpty()) {
-            return Optional.empty();
+        // Inferred crafting transformations apply only to loose-item intakes.
+        if (entities != null && !entities.isEmpty()) return explicit;
+
+        Optional<Scp914GenericRecipeResolver.GenericMatch> generic =
+                Scp914GenericRecipeResolver.find(level, setting, itemEntities);
+        if (generic.isEmpty()) return explicit;
+
+        Optional<Scp914RecipeManager.RecipeMatch> converted =
+                convert(setting, generic.get());
+        if (converted.isEmpty()) return explicit;
+        if (explicit.isEmpty()) return converted;
+
+        int totalInputs = Scp914RecipeManager.totalIntakeCount(itemEntities,
+                entities);
+        int explicitCount = Scp914RecipeManager.matchedInputCount(
+                explicit.get());
+        int genericCount = generic.get().matchedInputCount();
+        boolean explicitComplete = totalInputs > 0
+                && explicitCount >= totalInputs;
+        boolean genericComplete = generic.get().usesAllInputs();
+
+        if (genericComplete != explicitComplete) {
+            return genericComplete ? converted : explicit;
         }
-        return Scp914GenericRecipeResolver.find(level, setting, itemEntities)
-                .flatMap(match -> convert(setting, match));
+        // Explicit JSON remains authoritative when both candidates account for
+        // the same amount of the intake.
+        return genericCount > explicitCount ? converted : explicit;
     }
 
     private static Optional<Scp914RecipeManager.RecipeMatch> convert(
@@ -64,7 +87,8 @@ public final class Scp914RecipeBridge {
             if (stack == null || stack.isEmpty()) continue;
             ResourceLocation id = ForgeRegistries.ITEMS.getKey(stack.getItem());
             if (id == null) continue;
-            outputs.add(new Scp914RecipeManager.ItemOutput(id, stack.getCount()));
+            outputs.add(new Scp914RecipeManager.ItemOutput(id,
+                    stack.getCount()));
         }
         if (outputs.isEmpty()) return Optional.empty();
 
@@ -94,8 +118,12 @@ public final class Scp914RecipeBridge {
         List<Scp914RecipeManager.ItemUse> fullUses = new ArrayList<>();
         if (itemEntities != null) {
             for (ItemEntity entity : itemEntities) {
-                if (entity == null || entity.isRemoved() || entity.getItem().isEmpty()) continue;
-                fullUses.add(new Scp914RecipeManager.ItemUse(entity, entity.getItem().getCount()));
+                if (entity == null || entity.isRemoved()
+                        || entity.getItem().isEmpty()) {
+                    continue;
+                }
+                fullUses.add(new Scp914RecipeManager.ItemUse(entity,
+                        entity.getItem().getCount()));
             }
         }
         return new Scp914RecipeManager.RecipeMatch(

--- a/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeManager.java
+++ b/src/main/java/net/mcreator/scpadditions/data/Scp914RecipeManager.java
@@ -40,360 +40,515 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 public final class Scp914RecipeManager {
-	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
-	private static final Path CONFIG_ROOT = FMLPaths.CONFIGDIR.get().resolve("scpadditions");
-	private static final Path CONFIG_PATH = CONFIG_ROOT.resolve("914recipes.json");
-	private static final Path FRAGMENT_DIR = CONFIG_ROOT.resolve("914recipes.d");
-	private static final String BUNDLED_CONFIG = "config/scpadditions/914recipes.json";
-	private static final String DEFAULT_CONFIG = """
-			{
-			  "version": 2,
-			  "machine": {
-			    "intake_offset": [-5, 0, -3],
-			    "output_offset": [5, 0, -3],
-			    "search_radius": 1.5,
-			    "start_delay_ticks": 30,
-			    "finish_delay_ticks": 160
-			  },
-			  "recipes": [
-			    {
-			      "id": "scp_additions:level_1_keycard_rough",
-			      "enabled": true,
-			      "setting": "rough",
-			      "item_inputs": [{ "item": "scp_additions:level_1_keycard", "count": 1 }],
-			      "item_outputs": [{ "item": "scp_additions:pieces_of_paper", "count": 1 }],
-			      "chance": 1.0,
-			      "copy_input_nbt": false
-			    }
-			  ]
-			}
-			""";
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final Path CONFIG_ROOT = FMLPaths.CONFIGDIR.get().resolve("scpadditions");
+    private static final Path CONFIG_PATH = CONFIG_ROOT.resolve("914recipes.json");
+    private static final Path FRAGMENT_DIR = CONFIG_ROOT.resolve("914recipes.d");
+    private static final String BUNDLED_CONFIG = "config/scpadditions/914recipes.json";
+    private static final String DEFAULT_CONFIG = """
+            {
+              "version": 2,
+              "machine": {
+                "intake_offset": [-5, 0, -3],
+                "output_offset": [5, 0, -3],
+                "search_radius": 1.5,
+                "start_delay_ticks": 30,
+                "finish_delay_ticks": 160
+              },
+              "recipes": [
+                {
+                  "id": "scp_additions:level_1_keycard_rough",
+                  "enabled": true,
+                  "setting": "rough",
+                  "item_inputs": [{ "item": "scp_additions:level_1_keycard", "count": 1 }],
+                  "item_outputs": [{ "item": "scp_additions:pieces_of_paper", "count": 1 }],
+                  "chance": 1.0,
+                  "copy_input_nbt": false
+                }
+              ]
+            }
+            """;
 
-	private static List<RecipeDefinition> recipes = List.of();
-	private static MachineConfig machineConfig = MachineConfig.defaults();
+    private static List<RecipeDefinition> recipes = List.of();
+    private static MachineConfig machineConfig = MachineConfig.defaults();
 
-	private Scp914RecipeManager() {
-	}
+    private Scp914RecipeManager() {
+    }
 
-	public static synchronized void loadFromConfig() {
-		ensureConfigExists();
-		List<RecipeDefinition> parsed = new ArrayList<>();
-		readRecipeFile(CONFIG_PATH, parsed, true);
-		readFragmentFiles(parsed);
-		recipes = List.copyOf(parsed);
-		ScpAdditionsMod.LOGGER.info("Loaded {} SCP-914 recipe definitions from config", recipes.size());
-	}
+    public static synchronized void loadFromConfig() {
+        ensureConfigExists();
+        List<RecipeDefinition> parsed = new ArrayList<>();
+        readRecipeFile(CONFIG_PATH, parsed, true);
+        readFragmentFiles(parsed);
+        recipes = List.copyOf(parsed);
+        ScpAdditionsMod.LOGGER.info("Loaded {} SCP-914 recipe definitions from config", recipes.size());
+    }
 
-	private static void ensureConfigExists() {
-		try {
-			Files.createDirectories(CONFIG_ROOT);
-			Files.createDirectories(FRAGMENT_DIR);
-			if (Files.notExists(CONFIG_PATH)) {
-				writeDefaultConfig();
-			} else {
-				prettyPrintConfigIfNeeded(CONFIG_PATH);
-			}
-		} catch (IOException exception) {
-			ScpAdditionsMod.LOGGER.error("Failed to create SCP-914 config at {}", CONFIG_PATH, exception);
-		}
-	}
+    private static void ensureConfigExists() {
+        try {
+            Files.createDirectories(CONFIG_ROOT);
+            Files.createDirectories(FRAGMENT_DIR);
+            if (Files.notExists(CONFIG_PATH)) {
+                writeDefaultConfig();
+            } else {
+                prettyPrintConfigIfNeeded(CONFIG_PATH);
+            }
+        } catch (IOException exception) {
+            ScpAdditionsMod.LOGGER.error("Failed to create SCP-914 config at {}", CONFIG_PATH, exception);
+        }
+    }
 
-	private static void writeDefaultConfig() throws IOException {
-		try (InputStream stream = Scp914RecipeManager.class.getClassLoader().getResourceAsStream(BUNDLED_CONFIG)) {
-			if (stream != null) {
-				Files.copy(stream, CONFIG_PATH, StandardCopyOption.REPLACE_EXISTING);
-				return;
-			}
-		}
-		Files.writeString(CONFIG_PATH, DEFAULT_CONFIG, StandardCharsets.UTF_8);
-	}
+    private static void writeDefaultConfig() throws IOException {
+        try (InputStream stream = Scp914RecipeManager.class.getClassLoader().getResourceAsStream(BUNDLED_CONFIG)) {
+            if (stream != null) {
+                Files.copy(stream, CONFIG_PATH, StandardCopyOption.REPLACE_EXISTING);
+                return;
+            }
+        }
+        Files.writeString(CONFIG_PATH, DEFAULT_CONFIG, StandardCharsets.UTF_8);
+    }
 
-	private static void readFragmentFiles(List<RecipeDefinition> parsed) {
-		if (Files.notExists(FRAGMENT_DIR)) {
-			return;
-		}
-		try (Stream<Path> files = Files.list(FRAGMENT_DIR)) {
-			files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".json"))
-					.sorted(Comparator.comparing(path -> path.getFileName().toString()))
-					.forEach(path -> readRecipeFile(path, parsed, false));
-		} catch (IOException exception) {
-			ScpAdditionsMod.LOGGER.error("Failed to read SCP-914 recipe fragments from {}", FRAGMENT_DIR, exception);
-		}
-	}
+    private static void readFragmentFiles(List<RecipeDefinition> parsed) {
+        if (Files.notExists(FRAGMENT_DIR)) return;
+        try (Stream<Path> files = Files.list(FRAGMENT_DIR)) {
+            files.filter(path -> Files.isRegularFile(path)
+                            && path.getFileName().toString().endsWith(".json"))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .forEach(path -> readRecipeFile(path, parsed, false));
+        } catch (IOException exception) {
+            ScpAdditionsMod.LOGGER.error("Failed to read SCP-914 recipe fragments from {}", FRAGMENT_DIR, exception);
+        }
+    }
 
-	private static void readRecipeFile(Path path, List<RecipeDefinition> parsed, boolean readMachine) {
-		try {
-			prettyPrintConfigIfNeeded(path);
-			try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-				JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
-				if (readMachine) {
-					machineConfig = readMachineConfig(root);
-				}
-				JsonArray recipesArray = root.has("recipes") ? GsonHelper.getAsJsonArray(root, "recipes") : new JsonArray();
-				for (JsonElement element : recipesArray) {
-					try {
-						JsonObject json = GsonHelper.convertToJsonObject(element, "SCP-914 recipe");
-						if (json.has("enabled") && !GsonHelper.getAsBoolean(json, "enabled")) {
-							continue;
-						}
-						RecipeDefinition recipe = parseRecipe(json);
-						List<ResourceLocation> missing = unavailableRegistryEntries(recipe);
-						if (!missing.isEmpty()) {
-							ScpAdditionsMod.LOGGER.warn(
-									"Skipping SCP-914 recipe {} from {} because these registry IDs are unavailable: {}",
-									recipe.id(), path, missing);
-							continue;
-						}
-						parsed.add(recipe);
-					} catch (Exception exception) {
-						ScpAdditionsMod.LOGGER.error("Failed to load one SCP-914 recipe entry from {}", path, exception);
-					}
-				}
-			}
-		} catch (Exception exception) {
-			ScpAdditionsMod.LOGGER.error("Failed to load SCP-914 recipes from {}", path, exception);
-		}
-	}
+    private static void readRecipeFile(Path path, List<RecipeDefinition> parsed,
+                                       boolean readMachine) {
+        try {
+            prettyPrintConfigIfNeeded(path);
+            try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+                JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+                if (readMachine) machineConfig = readMachineConfig(root);
+                JsonArray recipesArray = root.has("recipes")
+                        ? GsonHelper.getAsJsonArray(root, "recipes") : new JsonArray();
+                for (JsonElement element : recipesArray) {
+                    try {
+                        JsonObject json = GsonHelper.convertToJsonObject(element,
+                                "SCP-914 recipe");
+                        if (json.has("enabled")
+                                && !GsonHelper.getAsBoolean(json, "enabled")) {
+                            continue;
+                        }
+                        RecipeDefinition recipe = parseRecipe(json);
+                        List<ResourceLocation> missing = unavailableRegistryEntries(recipe);
+                        if (!missing.isEmpty()) {
+                            ScpAdditionsMod.LOGGER.warn(
+                                    "Skipping SCP-914 recipe {} from {} because these registry IDs are unavailable: {}",
+                                    recipe.id(), path, missing);
+                            continue;
+                        }
+                        parsed.add(recipe);
+                    } catch (Exception exception) {
+                        ScpAdditionsMod.LOGGER.error(
+                                "Failed to load one SCP-914 recipe entry from {}",
+                                path, exception);
+                    }
+                }
+            }
+        } catch (Exception exception) {
+            ScpAdditionsMod.LOGGER.error("Failed to load SCP-914 recipes from {}",
+                    path, exception);
+        }
+    }
 
-	private static void prettyPrintConfigIfNeeded(Path path) throws IOException {
-		String content = Files.readString(path, StandardCharsets.UTF_8);
-		boolean looksMinified = !content.contains("\n") || content.lines().anyMatch(line -> line.length() > 240);
-		if (!looksMinified) {
-			return;
-		}
-		JsonElement json = JsonParser.parseString(content);
-		ConfigFilePersistence.writeWithBackup(path,
-				GSON.toJson(json) + System.lineSeparator());
-	}
+    private static void prettyPrintConfigIfNeeded(Path path) throws IOException {
+        String content = Files.readString(path, StandardCharsets.UTF_8);
+        boolean looksMinified = !content.contains("\n")
+                || content.lines().anyMatch(line -> line.length() > 240);
+        if (!looksMinified) return;
+        JsonElement json = JsonParser.parseString(content);
+        ConfigFilePersistence.writeWithBackup(path,
+                GSON.toJson(json) + System.lineSeparator());
+    }
 
-	private static List<ResourceLocation> unavailableRegistryEntries(RecipeDefinition recipe) {
-		LinkedHashSet<ResourceLocation> missing = new LinkedHashSet<>();
-		for (ItemIngredient input : recipe.itemInputs()) {
-			if (!ForgeRegistries.ITEMS.containsKey(input.item())) missing.add(input.item());
-		}
-		for (ItemOutput output : recipe.itemOutputs()) {
-			if (!ForgeRegistries.ITEMS.containsKey(output.item())) missing.add(output.item());
-		}
-		for (WeightedItemOutput output : recipe.weightedItemOutputs()) {
-			if (!ForgeRegistries.ITEMS.containsKey(output.output().item())) missing.add(output.output().item());
-		}
-		for (EntityIngredient input : recipe.entityInputs()) {
-			if (!ForgeRegistries.ENTITY_TYPES.containsKey(input.entity())) missing.add(input.entity());
-		}
-		for (EntityOutput output : recipe.entityOutputs()) {
-			if (!ForgeRegistries.ENTITY_TYPES.containsKey(output.entity())) missing.add(output.entity());
-		}
-		return List.copyOf(missing);
-	}
+    private static List<ResourceLocation> unavailableRegistryEntries(
+            RecipeDefinition recipe) {
+        LinkedHashSet<ResourceLocation> missing = new LinkedHashSet<>();
+        for (ItemIngredient input : recipe.itemInputs()) {
+            if (!ForgeRegistries.ITEMS.containsKey(input.item())) missing.add(input.item());
+        }
+        for (ItemOutput output : recipe.itemOutputs()) {
+            if (!ForgeRegistries.ITEMS.containsKey(output.item())) missing.add(output.item());
+        }
+        for (WeightedItemOutput output : recipe.weightedItemOutputs()) {
+            if (!ForgeRegistries.ITEMS.containsKey(output.output().item())) {
+                missing.add(output.output().item());
+            }
+        }
+        for (EntityIngredient input : recipe.entityInputs()) {
+            if (!ForgeRegistries.ENTITY_TYPES.containsKey(input.entity())) missing.add(input.entity());
+        }
+        for (EntityOutput output : recipe.entityOutputs()) {
+            if (!ForgeRegistries.ENTITY_TYPES.containsKey(output.entity())) missing.add(output.entity());
+        }
+        return List.copyOf(missing);
+    }
 
-	private static MachineConfig readMachineConfig(JsonObject root) {
-		if (!root.has("machine")) {
-			return MachineConfig.defaults();
-		}
-		JsonObject json = GsonHelper.getAsJsonObject(root, "machine");
-		return new MachineConfig(
-				readOffset(json, "intake_offset", -5, 0, -3),
-				readOffset(json, "output_offset", 5, 0, -3),
-				Math.max(0.5D, GsonHelper.getAsDouble(json, "search_radius", 1.5D)),
-				Math.max(0, GsonHelper.getAsInt(json, "start_delay_ticks", 30)),
-				Math.max(0, GsonHelper.getAsInt(json, "finish_delay_ticks", 160)));
-	}
+    private static MachineConfig readMachineConfig(JsonObject root) {
+        if (!root.has("machine")) return MachineConfig.defaults();
+        JsonObject json = GsonHelper.getAsJsonObject(root, "machine");
+        return new MachineConfig(
+                readOffset(json, "intake_offset", -5, 0, -3),
+                readOffset(json, "output_offset", 5, 0, -3),
+                Math.max(0.5D, GsonHelper.getAsDouble(json, "search_radius", 1.5D)),
+                Math.max(0, GsonHelper.getAsInt(json, "start_delay_ticks", 30)),
+                Math.max(0, GsonHelper.getAsInt(json, "finish_delay_ticks", 160)));
+    }
 
-	private static Offset readOffset(JsonObject json, String name, int defaultX, int defaultY, int defaultZ) {
-		if (!json.has(name)) {
-			return new Offset(defaultX, defaultY, defaultZ);
-		}
-		JsonArray array = GsonHelper.getAsJsonArray(json, name);
-		if (array.size() != 3) {
-			throw new IllegalArgumentException(name + " must have exactly 3 integers");
-		}
-		return new Offset(array.get(0).getAsInt(), array.get(1).getAsInt(), array.get(2).getAsInt());
-	}
+    private static Offset readOffset(JsonObject json, String name,
+                                     int defaultX, int defaultY, int defaultZ) {
+        if (!json.has(name)) return new Offset(defaultX, defaultY, defaultZ);
+        JsonArray array = GsonHelper.getAsJsonArray(json, name);
+        if (array.size() != 3) {
+            throw new IllegalArgumentException(name + " must have exactly 3 integers");
+        }
+        return new Offset(array.get(0).getAsInt(), array.get(1).getAsInt(),
+                array.get(2).getAsInt());
+    }
 
-	private static RecipeDefinition parseRecipe(JsonObject json) {
-		ResourceLocation id = new ResourceLocation(GsonHelper.getAsString(json, "id"));
-		Setting setting = Setting.fromSerializedName(GsonHelper.getAsString(json, "setting"));
-		List<ItemIngredient> itemInputs = readItemInputs(json);
-		List<EntityIngredient> entityInputs = readEntityInputs(json);
-		List<ItemOutput> itemOutputs = readItemOutputs(json);
-		List<WeightedItemOutput> weightedItemOutputs = readWeightedItemOutputs(json);
-		List<EntityOutput> entityOutputs = readEntityOutputs(json);
-		float chance = Math.max(0.0F, Math.min(1.0F, GsonHelper.getAsFloat(json, "chance", 1.0F)));
-		boolean copyInputNbt = GsonHelper.getAsBoolean(json, "copy_input_nbt", false);
-		String actionbar = GsonHelper.getAsString(json, "actionbar", "");
+    private static RecipeDefinition parseRecipe(JsonObject json) {
+        ResourceLocation id = new ResourceLocation(GsonHelper.getAsString(json, "id"));
+        Setting setting = Setting.fromSerializedName(
+                GsonHelper.getAsString(json, "setting"));
+        List<ItemIngredient> itemInputs = readItemInputs(json);
+        List<EntityIngredient> entityInputs = readEntityInputs(json);
+        List<ItemOutput> itemOutputs = readItemOutputs(json);
+        List<WeightedItemOutput> weightedItemOutputs = readWeightedItemOutputs(json);
+        List<EntityOutput> entityOutputs = readEntityOutputs(json);
+        float chance = Math.max(0.0F, Math.min(1.0F,
+                GsonHelper.getAsFloat(json, "chance", 1.0F)));
+        boolean copyInputNbt = GsonHelper.getAsBoolean(json,
+                "copy_input_nbt", false);
+        String actionbar = GsonHelper.getAsString(json, "actionbar", "");
 
-		if (itemInputs.isEmpty() && entityInputs.isEmpty()) {
-			throw new IllegalArgumentException("SCP-914 recipe " + id + " has no inputs");
-		}
-		if (itemOutputs.isEmpty() && weightedItemOutputs.isEmpty() && entityOutputs.isEmpty()) {
-			throw new IllegalArgumentException("SCP-914 recipe " + id + " has no outputs");
-		}
-		return new RecipeDefinition(id, setting, itemInputs, entityInputs, itemOutputs, weightedItemOutputs, entityOutputs, chance, copyInputNbt, actionbar);
-	}
+        if (itemInputs.isEmpty() && entityInputs.isEmpty()) {
+            throw new IllegalArgumentException("SCP-914 recipe " + id
+                    + " has no inputs");
+        }
+        if (itemOutputs.isEmpty() && weightedItemOutputs.isEmpty()
+                && entityOutputs.isEmpty()) {
+            throw new IllegalArgumentException("SCP-914 recipe " + id
+                    + " has no outputs");
+        }
+        return new RecipeDefinition(id, setting, itemInputs, entityInputs,
+                itemOutputs, weightedItemOutputs, entityOutputs, chance,
+                copyInputNbt, actionbar);
+    }
 
-	private static List<ItemIngredient> readItemInputs(JsonObject json) {
-		List<ItemIngredient> inputs = new ArrayList<>();
-		if (json.has("input")) {
-			JsonObject input = GsonHelper.getAsJsonObject(json, "input");
-			inputs.add(new ItemIngredient(new ResourceLocation(GsonHelper.getAsString(input, "item")), Math.max(1, GsonHelper.getAsInt(input, "count", 1))));
-		}
-		if (json.has("item_inputs")) {
-			JsonArray array = GsonHelper.getAsJsonArray(json, "item_inputs");
-			for (JsonElement element : array) {
-				JsonObject input = GsonHelper.convertToJsonObject(element, "SCP-914 item input");
-				inputs.add(new ItemIngredient(new ResourceLocation(GsonHelper.getAsString(input, "item")), Math.max(1, GsonHelper.getAsInt(input, "count", 1))));
-			}
-		}
-		return List.copyOf(inputs);
-	}
+    private static List<ItemIngredient> readItemInputs(JsonObject json) {
+        List<ItemIngredient> inputs = new ArrayList<>();
+        if (json.has("input")) {
+            JsonObject input = GsonHelper.getAsJsonObject(json, "input");
+            inputs.add(new ItemIngredient(new ResourceLocation(
+                    GsonHelper.getAsString(input, "item")),
+                    Math.max(1, GsonHelper.getAsInt(input, "count", 1))));
+        }
+        if (json.has("item_inputs")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json, "item_inputs");
+            for (JsonElement element : array) {
+                JsonObject input = GsonHelper.convertToJsonObject(element,
+                        "SCP-914 item input");
+                inputs.add(new ItemIngredient(new ResourceLocation(
+                        GsonHelper.getAsString(input, "item")),
+                        Math.max(1, GsonHelper.getAsInt(input, "count", 1))));
+            }
+        }
+        return List.copyOf(inputs);
+    }
 
-	private static List<EntityIngredient> readEntityInputs(JsonObject json) {
-		List<EntityIngredient> inputs = new ArrayList<>();
-		if (json.has("entity_inputs")) {
-			JsonArray array = GsonHelper.getAsJsonArray(json, "entity_inputs");
-			for (JsonElement element : array) {
-				JsonObject input = GsonHelper.convertToJsonObject(element, "SCP-914 entity input");
-				inputs.add(new EntityIngredient(new ResourceLocation(GsonHelper.getAsString(input, "entity")), Math.max(1, GsonHelper.getAsInt(input, "count", 1)), GsonHelper.getAsBoolean(input, "consume", true)));
-			}
-		}
-		return List.copyOf(inputs);
-	}
+    private static List<EntityIngredient> readEntityInputs(JsonObject json) {
+        List<EntityIngredient> inputs = new ArrayList<>();
+        if (json.has("entity_inputs")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json, "entity_inputs");
+            for (JsonElement element : array) {
+                JsonObject input = GsonHelper.convertToJsonObject(element,
+                        "SCP-914 entity input");
+                inputs.add(new EntityIngredient(new ResourceLocation(
+                        GsonHelper.getAsString(input, "entity")),
+                        Math.max(1, GsonHelper.getAsInt(input, "count", 1)),
+                        GsonHelper.getAsBoolean(input, "consume", true)));
+            }
+        }
+        return List.copyOf(inputs);
+    }
 
-	private static List<ItemOutput> readItemOutputs(JsonObject json) {
-		List<ItemOutput> outputs = new ArrayList<>();
-		if (json.has("output")) {
-			JsonObject output = GsonHelper.getAsJsonObject(json, "output");
-			outputs.add(new ItemOutput(new ResourceLocation(GsonHelper.getAsString(output, "item")), Math.max(1, GsonHelper.getAsInt(output, "count", 1))));
-		}
-		if (json.has("item_outputs")) {
-			JsonArray array = GsonHelper.getAsJsonArray(json, "item_outputs");
-			for (JsonElement element : array) {
-				JsonObject output = GsonHelper.convertToJsonObject(element, "SCP-914 item output");
-				outputs.add(new ItemOutput(new ResourceLocation(GsonHelper.getAsString(output, "item")), Math.max(1, GsonHelper.getAsInt(output, "count", 1))));
-			}
-		}
-		return List.copyOf(outputs);
-	}
+    private static List<ItemOutput> readItemOutputs(JsonObject json) {
+        List<ItemOutput> outputs = new ArrayList<>();
+        if (json.has("output")) {
+            JsonObject output = GsonHelper.getAsJsonObject(json, "output");
+            outputs.add(new ItemOutput(new ResourceLocation(
+                    GsonHelper.getAsString(output, "item")),
+                    Math.max(1, GsonHelper.getAsInt(output, "count", 1))));
+        }
+        if (json.has("item_outputs")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json, "item_outputs");
+            for (JsonElement element : array) {
+                JsonObject output = GsonHelper.convertToJsonObject(element,
+                        "SCP-914 item output");
+                outputs.add(new ItemOutput(new ResourceLocation(
+                        GsonHelper.getAsString(output, "item")),
+                        Math.max(1, GsonHelper.getAsInt(output, "count", 1))));
+            }
+        }
+        return List.copyOf(outputs);
+    }
 
-	private static List<WeightedItemOutput> readWeightedItemOutputs(JsonObject json) {
-		List<WeightedItemOutput> outputs = new ArrayList<>();
-		if (json.has("weighted_item_outputs")) {
-			JsonArray array = GsonHelper.getAsJsonArray(json, "weighted_item_outputs");
-			for (JsonElement element : array) {
-				JsonObject output = GsonHelper.convertToJsonObject(element, "SCP-914 weighted item output");
-				outputs.add(new WeightedItemOutput(Math.max(1, GsonHelper.getAsInt(output, "weight", 1)), new ItemOutput(new ResourceLocation(GsonHelper.getAsString(output, "item")), Math.max(1, GsonHelper.getAsInt(output, "count", 1)))));
-			}
-		}
-		return List.copyOf(outputs);
-	}
+    private static List<WeightedItemOutput> readWeightedItemOutputs(
+            JsonObject json) {
+        List<WeightedItemOutput> outputs = new ArrayList<>();
+        if (json.has("weighted_item_outputs")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json,
+                    "weighted_item_outputs");
+            for (JsonElement element : array) {
+                JsonObject output = GsonHelper.convertToJsonObject(element,
+                        "SCP-914 weighted item output");
+                outputs.add(new WeightedItemOutput(
+                        Math.max(1, GsonHelper.getAsInt(output, "weight", 1)),
+                        new ItemOutput(new ResourceLocation(
+                                GsonHelper.getAsString(output, "item")),
+                                Math.max(1, GsonHelper.getAsInt(output,
+                                        "count", 1)))));
+            }
+        }
+        return List.copyOf(outputs);
+    }
 
-	private static List<EntityOutput> readEntityOutputs(JsonObject json) {
-		List<EntityOutput> outputs = new ArrayList<>();
-		if (json.has("entity_outputs")) {
-			JsonArray array = GsonHelper.getAsJsonArray(json, "entity_outputs");
-			for (JsonElement element : array) {
-				JsonObject output = GsonHelper.convertToJsonObject(element, "SCP-914 entity output");
-				outputs.add(new EntityOutput(new ResourceLocation(GsonHelper.getAsString(output, "entity")), Math.max(1, GsonHelper.getAsInt(output, "count", 1))));
-			}
-		}
-		return List.copyOf(outputs);
-	}
+    private static List<EntityOutput> readEntityOutputs(JsonObject json) {
+        List<EntityOutput> outputs = new ArrayList<>();
+        if (json.has("entity_outputs")) {
+            JsonArray array = GsonHelper.getAsJsonArray(json, "entity_outputs");
+            for (JsonElement element : array) {
+                JsonObject output = GsonHelper.convertToJsonObject(element,
+                        "SCP-914 entity output");
+                outputs.add(new EntityOutput(new ResourceLocation(
+                        GsonHelper.getAsString(output, "entity")),
+                        Math.max(1, GsonHelper.getAsInt(output, "count", 1))));
+            }
+        }
+        return List.copyOf(outputs);
+    }
 
-	public static Optional<RecipeMatch> findRecipe(Setting setting, List<ItemEntity> itemEntities, List<Entity> entities) {
-		return recipes.stream().filter(recipe -> recipe.setting() == setting).map(recipe -> match(recipe, itemEntities, entities)).filter(Optional::isPresent).map(Optional::get).findFirst();
-	}
+    /**
+     * Selects the most specific configured recipe instead of whichever matching
+     * entry happens to appear first in the JSON files. A recipe that accounts
+     * for the complete intake wins; otherwise the recipe using the greatest
+     * number of item/entity units wins. Configuration order remains the final
+     * tie-breaker so existing equal recipes stay deterministic.
+     */
+    public static Optional<RecipeMatch> findRecipe(Setting setting,
+            List<ItemEntity> itemEntities, List<Entity> entities) {
+        int totalInputs = totalIntakeCount(itemEntities, entities);
+        RecipeMatch selected = null;
+        for (RecipeDefinition recipe : recipes) {
+            if (recipe.setting() != setting) continue;
+            Optional<RecipeMatch> candidate = match(recipe, itemEntities, entities);
+            if (candidate.isEmpty()) continue;
+            if (selected == null || isBetterMatch(candidate.get(), selected,
+                    totalInputs)) {
+                selected = candidate.get();
+            }
+        }
+        return Optional.ofNullable(selected);
+    }
 
-	private static Optional<RecipeMatch> match(RecipeDefinition recipe, List<ItemEntity> itemEntities, List<Entity> entities) {
-		List<ItemUse> itemUses = new ArrayList<>();
-		Map<ItemEntity, Integer> reservedItemCounts = new HashMap<>();
-		for (ItemIngredient ingredient : recipe.itemInputs()) {
-			int remaining = ingredient.count();
-			for (ItemEntity itemEntity : itemEntities) {
-				ItemStack stack = itemEntity.getItem();
-				ResourceLocation stackId = ForgeRegistries.ITEMS.getKey(stack.getItem());
-				if (!ingredient.item().equals(stackId)) continue;
-				int alreadyReserved = reservedItemCounts.getOrDefault(itemEntity, 0);
-				int available = stack.getCount() - alreadyReserved;
-				if (available <= 0) continue;
-				int used = Math.min(available, remaining);
-				reservedItemCounts.put(itemEntity, alreadyReserved + used);
-				itemUses.add(new ItemUse(itemEntity, used));
-				remaining -= used;
-				if (remaining <= 0) break;
-			}
-			if (remaining > 0) return Optional.empty();
-		}
+    private static boolean isBetterMatch(RecipeMatch candidate,
+            RecipeMatch current, int totalInputs) {
+        int candidateCount = matchedInputCount(candidate);
+        int currentCount = matchedInputCount(current);
+        boolean candidateComplete = totalInputs > 0
+                && candidateCount >= totalInputs;
+        boolean currentComplete = totalInputs > 0
+                && currentCount >= totalInputs;
+        if (candidateComplete != currentComplete) return candidateComplete;
+        return candidateCount > currentCount;
+    }
 
-		List<EntityUse> entityUses = new ArrayList<>();
-		List<Entity> reservedEntities = new ArrayList<>();
-		for (EntityIngredient ingredient : recipe.entityInputs()) {
-			int remaining = ingredient.count();
-			for (Entity entity : entities) {
-				if (reservedEntities.contains(entity)) continue;
-				ResourceLocation entityId = ForgeRegistries.ENTITY_TYPES.getKey(entity.getType());
-				if (!ingredient.entity().equals(entityId)) continue;
-				reservedEntities.add(entity);
-				entityUses.add(new EntityUse(entity, ingredient.consume()));
-				remaining--;
-				if (remaining <= 0) break;
-			}
-			if (remaining > 0) return Optional.empty();
-		}
-		return Optional.of(new RecipeMatch(recipe, List.copyOf(itemUses), List.copyOf(entityUses)));
-	}
+    public static int matchedInputCount(RecipeMatch match) {
+        if (match == null) return 0;
+        int itemCount = match.itemUses().stream()
+                .mapToInt(ItemUse::count).sum();
+        return itemCount + match.entityUses().size();
+    }
 
-	public static List<ItemOutput> rollItemOutputs(RecipeDefinition recipe, RandomSource random) {
-		if (recipe.weightedItemOutputs().isEmpty()) return recipe.itemOutputs();
-		int totalWeight = recipe.weightedItemOutputs().stream().mapToInt(WeightedItemOutput::weight).sum();
-		int roll = random.nextInt(Math.max(1, totalWeight));
-		for (WeightedItemOutput output : recipe.weightedItemOutputs()) {
-			roll -= output.weight();
-			if (roll < 0) return List.of(output.output());
-		}
-		return List.of(recipe.weightedItemOutputs().get(0).output());
-	}
+    public static int totalIntakeCount(List<ItemEntity> itemEntities,
+            List<Entity> entities) {
+        int total = 0;
+        if (itemEntities != null) {
+            for (ItemEntity entity : itemEntities) {
+                if (entity != null && !entity.isRemoved()
+                        && !entity.getItem().isEmpty()) {
+                    total += entity.getItem().getCount();
+                }
+            }
+        }
+        if (entities != null) {
+            for (Entity entity : entities) {
+                if (entity != null && !entity.isRemoved()) total++;
+            }
+        }
+        return total;
+    }
 
-	public static ItemStack createItemOutput(ItemOutput output, ItemStack inputStack, boolean copyInputNbt) {
-		Item item = ForgeRegistries.ITEMS.getValue(output.item());
-		if (item == null || item == Items.AIR) {
-			ScpAdditionsMod.LOGGER.warn("SCP-914 output points to missing item {}", output.item());
-			return ItemStack.EMPTY;
-		}
-		ItemStack result = new ItemStack(item, output.count());
-		if (copyInputNbt && inputStack != null && inputStack.hasTag()) result.setTag(inputStack.getTag().copy());
-		return result;
-	}
+    private static Optional<RecipeMatch> match(RecipeDefinition recipe,
+            List<ItemEntity> itemEntities, List<Entity> entities) {
+        List<ItemUse> itemUses = new ArrayList<>();
+        Map<ItemEntity, Integer> reservedItemCounts = new HashMap<>();
+        for (ItemIngredient ingredient : recipe.itemInputs()) {
+            int remaining = ingredient.count();
+            for (ItemEntity itemEntity : itemEntities) {
+                ItemStack stack = itemEntity.getItem();
+                ResourceLocation stackId = ForgeRegistries.ITEMS.getKey(
+                        stack.getItem());
+                if (!ingredient.item().equals(stackId)) continue;
+                int alreadyReserved = reservedItemCounts.getOrDefault(
+                        itemEntity, 0);
+                int available = stack.getCount() - alreadyReserved;
+                if (available <= 0) continue;
+                int used = Math.min(available, remaining);
+                reservedItemCounts.put(itemEntity, alreadyReserved + used);
+                itemUses.add(new ItemUse(itemEntity, used));
+                remaining -= used;
+                if (remaining <= 0) break;
+            }
+            if (remaining > 0) return Optional.empty();
+        }
 
-	public static Optional<EntityType<?>> getEntityType(EntityOutput output) {
-		EntityType<?> type = ForgeRegistries.ENTITY_TYPES.getValue(output.entity());
-		return Optional.ofNullable(type);
-	}
+        List<EntityUse> entityUses = new ArrayList<>();
+        List<Entity> reservedEntities = new ArrayList<>();
+        for (EntityIngredient ingredient : recipe.entityInputs()) {
+            int remaining = ingredient.count();
+            for (Entity entity : entities) {
+                if (reservedEntities.contains(entity)) continue;
+                ResourceLocation entityId = ForgeRegistries.ENTITY_TYPES.getKey(
+                        entity.getType());
+                if (!ingredient.entity().equals(entityId)) continue;
+                reservedEntities.add(entity);
+                entityUses.add(new EntityUse(entity, ingredient.consume()));
+                remaining--;
+                if (remaining <= 0) break;
+            }
+            if (remaining > 0) return Optional.empty();
+        }
+        return Optional.of(new RecipeMatch(recipe, List.copyOf(itemUses),
+                List.copyOf(entityUses)));
+    }
 
-	public static MachineConfig machineConfig() {
-		return machineConfig;
-	}
+    public static List<ItemOutput> rollItemOutputs(RecipeDefinition recipe,
+            RandomSource random) {
+        if (recipe.weightedItemOutputs().isEmpty()) return recipe.itemOutputs();
+        int totalWeight = recipe.weightedItemOutputs().stream()
+                .mapToInt(WeightedItemOutput::weight).sum();
+        int roll = random.nextInt(Math.max(1, totalWeight));
+        for (WeightedItemOutput output : recipe.weightedItemOutputs()) {
+            roll -= output.weight();
+            if (roll < 0) return List.of(output.output());
+        }
+        return List.of(recipe.weightedItemOutputs().get(0).output());
+    }
 
-	public enum Setting {
-		ROUGH("rough"), COARSE("coarse"), ONE_TO_ONE("1_to_1"), FINE("fine"), VERY_FINE("very_fine");
-		private final String serializedName;
-		Setting(String serializedName) { this.serializedName = serializedName; }
-		public String serializedName() { return serializedName; }
-		public static Setting fromSerializedName(String value) {
-			String normalized = value.trim().toLowerCase(Locale.ROOT);
-			for (Setting setting : values()) if (setting.serializedName.equals(normalized)) return setting;
-			throw new IllegalArgumentException("Unknown SCP-914 setting: " + value);
-		}
-	}
+    public static ItemStack createItemOutput(ItemOutput output,
+            ItemStack inputStack, boolean copyInputNbt) {
+        Item item = ForgeRegistries.ITEMS.getValue(output.item());
+        if (item == null || item == Items.AIR) {
+            ScpAdditionsMod.LOGGER.warn(
+                    "SCP-914 output points to missing item {}", output.item());
+            return ItemStack.EMPTY;
+        }
+        ItemStack result = new ItemStack(item, output.count());
+        if (copyInputNbt && inputStack != null && inputStack.hasTag()) {
+            result.setTag(inputStack.getTag().copy());
+        }
+        return result;
+    }
 
-	public record RecipeDefinition(ResourceLocation id, Setting setting, List<ItemIngredient> itemInputs, List<EntityIngredient> entityInputs, List<ItemOutput> itemOutputs, List<WeightedItemOutput> weightedItemOutputs, List<EntityOutput> entityOutputs, float chance, boolean copyInputNbt, String actionbar) {}
-	public record ItemIngredient(ResourceLocation item, int count) {}
-	public record EntityIngredient(ResourceLocation entity, int count, boolean consume) {}
-	public record ItemOutput(ResourceLocation item, int count) {}
-	public record WeightedItemOutput(int weight, ItemOutput output) {}
-	public record EntityOutput(ResourceLocation entity, int count) {}
-	public record ItemUse(ItemEntity entity, int count) {}
-	public record EntityUse(Entity entity, boolean consume) {}
-	public record RecipeMatch(RecipeDefinition recipe, List<ItemUse> itemUses, List<EntityUse> entityUses) { public ItemStack firstInputStack() { return itemUses.isEmpty() ? ItemStack.EMPTY : itemUses.get(0).entity().getItem(); } }
-	public record MachineConfig(Offset intakeOffset, Offset outputOffset, double searchRadius, int startDelayTicks, int finishDelayTicks) { public static MachineConfig defaults() { return new MachineConfig(new Offset(-5, 0, -3), new Offset(5, 0, -3), 1.5D, 30, 160); } }
-	public record Offset(int x, int y, int z) {}
+    public static Optional<EntityType<?>> getEntityType(EntityOutput output) {
+        EntityType<?> type = ForgeRegistries.ENTITY_TYPES.getValue(output.entity());
+        return Optional.ofNullable(type);
+    }
+
+    public static MachineConfig machineConfig() {
+        return machineConfig;
+    }
+
+    public enum Setting {
+        ROUGH("rough"), COARSE("coarse"), ONE_TO_ONE("1_to_1"),
+        FINE("fine"), VERY_FINE("very_fine");
+
+        private final String serializedName;
+
+        Setting(String serializedName) {
+            this.serializedName = serializedName;
+        }
+
+        public String serializedName() {
+            return serializedName;
+        }
+
+        public static Setting fromSerializedName(String value) {
+            String normalized = value.trim().toLowerCase(Locale.ROOT);
+            for (Setting setting : values()) {
+                if (setting.serializedName.equals(normalized)) return setting;
+            }
+            throw new IllegalArgumentException(
+                    "Unknown SCP-914 setting: " + value);
+        }
+    }
+
+    public record RecipeDefinition(ResourceLocation id, Setting setting,
+            List<ItemIngredient> itemInputs,
+            List<EntityIngredient> entityInputs,
+            List<ItemOutput> itemOutputs,
+            List<WeightedItemOutput> weightedItemOutputs,
+            List<EntityOutput> entityOutputs, float chance,
+            boolean copyInputNbt, String actionbar) {
+    }
+
+    public record ItemIngredient(ResourceLocation item, int count) {
+    }
+
+    public record EntityIngredient(ResourceLocation entity, int count,
+            boolean consume) {
+    }
+
+    public record ItemOutput(ResourceLocation item, int count) {
+    }
+
+    public record WeightedItemOutput(int weight, ItemOutput output) {
+    }
+
+    public record EntityOutput(ResourceLocation entity, int count) {
+    }
+
+    public record ItemUse(ItemEntity entity, int count) {
+    }
+
+    public record EntityUse(Entity entity, boolean consume) {
+    }
+
+    public record RecipeMatch(RecipeDefinition recipe,
+            List<ItemUse> itemUses, List<EntityUse> entityUses) {
+        public ItemStack firstInputStack() {
+            return itemUses.isEmpty() ? ItemStack.EMPTY
+                    : itemUses.get(0).entity().getItem();
+        }
+    }
+
+    public record MachineConfig(Offset intakeOffset, Offset outputOffset,
+            double searchRadius, int startDelayTicks, int finishDelayTicks) {
+        public static MachineConfig defaults() {
+            return new MachineConfig(new Offset(-5, 0, -3),
+                    new Offset(5, 0, -3), 1.5D, 30, 160);
+        }
+    }
+
+    public record Offset(int x, int y, int z) {
+    }
 }

--- a/src/main/java/net/mcreator/scpadditions/event/BlinkWatcherAggroEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/event/BlinkWatcherAggroEvents.java
@@ -8,6 +8,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.mcreator.scpadditions.ScpAdditionsMod;
 import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
+import net.mcreator.scpadditions.entity.BlinkServerState;
 import net.mcreator.scpadditions.entity.BlinkWatcherEntity;
 import net.mcreator.scpadditions.entity.Scp173Entity;
 import net.mcreator.scpadditions.network.ScpEntityNetwork;
@@ -16,7 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-@Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID,
+        bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class BlinkWatcherAggroEvents {
     private static final Map<UUID, Boolean> LAST_ACTIVE = new HashMap<>();
     private static final Map<UUID, Boolean> LAST_CLOSE_REVEAL = new HashMap<>();
@@ -29,11 +31,14 @@ public final class BlinkWatcherAggroEvents {
     private static final Map<ObservationKey, Integer> LAST_CLOSE_OBSERVED_TICK = new HashMap<>();
     private static final Map<ObservationKey, Vec3> LAST_CLOSE_OBSERVED_POSITION = new HashMap<>();
     private static final double THREAT_MEMORY_DISTANCE = 48.0D;
-    private static final double THREAT_MEMORY_DISTANCE_SQR = THREAT_MEMORY_DISTANCE * THREAT_MEMORY_DISTANCE;
+    private static final double THREAT_MEMORY_DISTANCE_SQR =
+            THREAT_MEMORY_DISTANCE * THREAT_MEMORY_DISTANCE;
     private static final double VISUAL_CONFIRM_DISTANCE = 20.0D;
-    private static final double VISUAL_CONFIRM_DISTANCE_SQR = VISUAL_CONFIRM_DISTANCE * VISUAL_CONFIRM_DISTANCE;
+    private static final double VISUAL_CONFIRM_DISTANCE_SQR =
+            VISUAL_CONFIRM_DISTANCE * VISUAL_CONFIRM_DISTANCE;
     private static final double CLOSE_REVEAL_DISTANCE = 5.0D;
-    private static final double CLOSE_REVEAL_DISTANCE_SQR = CLOSE_REVEAL_DISTANCE * CLOSE_REVEAL_DISTANCE;
+    private static final double CLOSE_REVEAL_DISTANCE_SQR =
+            CLOSE_REVEAL_DISTANCE * CLOSE_REVEAL_DISTANCE;
     private static final double REVEAL_TRAVEL_DISTANCE_SQR = 2.25D * 2.25D;
     private static final float REPEAT_REVEAL_SOUND_CHANCE = 0.35F;
     private static final int REVEAL_UNOBSERVED_TICKS = 40;
@@ -45,16 +50,28 @@ public final class BlinkWatcherAggroEvents {
 
     @SubscribeEvent
     public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
-        if (event.phase != TickEvent.Phase.END || event.player.level().isClientSide
-                || !(event.player instanceof ServerPlayer player)) return;
+        if (event.phase != TickEvent.Phase.END
+                || event.player.level().isClientSide
+                || !(event.player instanceof ServerPlayer player)) {
+            return;
+        }
 
         UUID id = player.getUUID();
-        if (!ScpAdditionsModulesConfig.get().scp173.enabled) {
+        boolean allowed = ScpAdditionsModulesConfig.get().scp173.enabled
+                && ScpAdditionsModulesConfig.get().blink.enabled
+                && !player.isCreative() && !player.isSpectator();
+        if (!allowed) {
             boolean wasActive = LAST_ACTIVE.getOrDefault(id, false);
             LAST_ACTIVE.put(id, false);
-            LAST_CLOSE_REVEAL.remove(id);
-            LAST_THREAT_TICK.remove(id);
-            if (wasActive || player.tickCount % 40 == 0) ScpEntityNetwork.setBlinkActive(player, false);
+            clearPlayerMemory(id);
+            boolean wasClosed = BlinkServerState.setBlinkClosed(player,
+                    false, false);
+            if (wasClosed) {
+                Scp173Entity.reactToBlinkState(player, false, false);
+            }
+            if (wasActive || player.tickCount % 40 == 0) {
+                ScpEntityNetwork.setBlinkActive(player, false);
+            }
             return;
         }
 
@@ -62,14 +79,20 @@ public final class BlinkWatcherAggroEvents {
         boolean rawActive = threat.active();
         boolean closeReveal = threat.closeObservedReveal();
         boolean previousActive = LAST_ACTIVE.getOrDefault(id, false);
-        boolean previousCloseReveal = LAST_CLOSE_REVEAL.getOrDefault(id, false);
+        boolean previousCloseReveal = LAST_CLOSE_REVEAL.getOrDefault(id,
+                false);
         if (rawActive) LAST_THREAT_TICK.put(id, player.tickCount);
-        boolean active = rawActive || (threat.hasWatcher() && shouldKeepHudForParanoia(player, id));
+        boolean active = rawActive || (threat.hasWatcher()
+                && shouldKeepHudForParanoia(player, id));
         if (!threat.hasWatcher() && !active) {
             LAST_THREAT_TICK.remove(id);
             LAST_CLOSE_REVEAL.remove(id);
         }
-        if (closeReveal && !previousCloseReveal && !maybeSendRevealSound(player, id, threat.forceRevealSound())) closeReveal = false;
+        if (closeReveal && !previousCloseReveal
+                && !maybeSendRevealSound(player, id,
+                threat.forceRevealSound())) {
+            closeReveal = false;
+        }
         LAST_CLOSE_REVEAL.put(id, closeReveal);
         if (active != previousActive || player.tickCount % 40 == 0) {
             LAST_ACTIVE.put(id, active);
@@ -77,12 +100,37 @@ public final class BlinkWatcherAggroEvents {
         }
     }
 
+    private static void clearPlayerMemory(UUID playerId) {
+        LAST_CLOSE_REVEAL.remove(playerId);
+        LAST_THREAT_TICK.remove(playerId);
+        LAST_REVEAL_SOUND_TICK.remove(playerId);
+        LAST_OBSERVED_TICK.keySet().removeIf(key ->
+                key.playerId().equals(playerId));
+        LAST_OBSERVED_POSITION.keySet().removeIf(key ->
+                key.playerId().equals(playerId));
+        LAST_CONFIRMED_OBSERVED_TICK.keySet().removeIf(key ->
+                key.playerId().equals(playerId));
+        LAST_CONFIRMED_OBSERVED_POSITION.keySet().removeIf(key ->
+                key.playerId().equals(playerId));
+        LAST_CLOSE_OBSERVED_TICK.keySet().removeIf(key ->
+                key.playerId().equals(playerId));
+        LAST_CLOSE_OBSERVED_POSITION.keySet().removeIf(key ->
+                key.playerId().equals(playerId));
+    }
+
     private static ThreatState findThreatState(ServerPlayer player) {
-        if (player == null || player.isCreative() || player.isSpectator()) return ThreatState.INACTIVE;
+        if (player == null || player.isCreative() || player.isSpectator()) {
+            return ThreatState.INACTIVE;
+        }
         AABB area = player.getBoundingBox().inflate(THREAT_MEMORY_DISTANCE);
-        boolean active = false, closeReveal = false, forceSound = false, hasWatcher = false;
-        for (BlinkWatcherEntity watcher : player.serverLevel().getEntitiesOfClass(BlinkWatcherEntity.class, area,
-                watcher -> watcher.isAlive() && shouldTrackWatcher(player, watcher))) {
+        boolean active = false;
+        boolean closeReveal = false;
+        boolean forceSound = false;
+        boolean hasWatcher = false;
+        for (BlinkWatcherEntity watcher : player.serverLevel()
+                .getEntitiesOfClass(BlinkWatcherEntity.class, area,
+                        watcher -> watcher.isAlive()
+                                && shouldTrackWatcher(player, watcher))) {
             hasWatcher = true;
             if (shouldShowBlinkHud(player, watcher)) active = true;
             if (watcher instanceof Scp173Entity scp173) {
@@ -99,40 +147,62 @@ public final class BlinkWatcherAggroEvents {
         return new ThreatState(active, closeReveal, hasWatcher, forceSound);
     }
 
-    private static boolean shouldTrackWatcher(ServerPlayer player, BlinkWatcherEntity watcher) {
+    private static boolean shouldTrackWatcher(ServerPlayer player,
+            BlinkWatcherEntity watcher) {
         if (watcher.getTarget() == player) return true;
-        return watcher instanceof Scp173Entity scp173 && (scp173.isObservedBy(player) || wasObservedBefore(player, scp173))
-                && scp173.distanceToSqr(player) <= THREAT_MEMORY_DISTANCE_SQR;
+        return watcher instanceof Scp173Entity scp173
+                && (scp173.isObservedBy(player)
+                || wasObservedBefore(player, scp173))
+                && scp173.distanceToSqr(player)
+                <= THREAT_MEMORY_DISTANCE_SQR;
     }
 
-    private static boolean shouldShowBlinkHud(ServerPlayer player, BlinkWatcherEntity watcher) {
-        return watcher instanceof Scp173Entity scp173 ? isConfirmedVisualThreat(player, scp173) : watcher.getTarget() == player;
+    private static boolean shouldShowBlinkHud(ServerPlayer player,
+            BlinkWatcherEntity watcher) {
+        return watcher instanceof Scp173Entity scp173
+                ? isConfirmedVisualThreat(player, scp173)
+                : watcher.getTarget() == player;
     }
 
-    private static RevealState revealState(ServerPlayer player, Scp173Entity scp173) {
+    private static RevealState revealState(ServerPlayer player,
+            Scp173Entity scp173) {
         if (!isConfirmedVisualThreat(player, scp173)) return RevealState.NONE;
         ObservationKey key = observationKey(player, scp173);
         double distanceSqr = scp173.distanceToSqr(player);
-        if (!LAST_CONFIRMED_OBSERVED_TICK.containsKey(key)) return new RevealState(true, true);
-        int lastObserved = LAST_OBSERVED_TICK.getOrDefault(key, player.tickCount);
-        int lastClose = LAST_CLOSE_OBSERVED_TICK.getOrDefault(key, -REVEAL_UNOBSERVED_TICKS);
-        Vec3 lastConfirmedPosition = LAST_CONFIRMED_OBSERVED_POSITION.getOrDefault(key, scp173.position());
-        Vec3 lastClosePosition = LAST_CLOSE_OBSERVED_POSITION.getOrDefault(key, scp173.position());
-        boolean unobserved = player.tickCount - lastObserved >= REVEAL_UNOBSERVED_TICKS;
-        boolean moved = scp173.position().distanceToSqr(lastConfirmedPosition) >= REVEAL_TRAVEL_DISTANCE_SQR;
+        if (!LAST_CONFIRMED_OBSERVED_TICK.containsKey(key)) {
+            return new RevealState(true, true);
+        }
+        int lastObserved = LAST_OBSERVED_TICK.getOrDefault(key,
+                player.tickCount);
+        int lastClose = LAST_CLOSE_OBSERVED_TICK.getOrDefault(key,
+                -REVEAL_UNOBSERVED_TICKS);
+        Vec3 lastConfirmedPosition = LAST_CONFIRMED_OBSERVED_POSITION
+                .getOrDefault(key, scp173.position());
+        Vec3 lastClosePosition = LAST_CLOSE_OBSERVED_POSITION.getOrDefault(
+                key, scp173.position());
+        boolean unobserved = player.tickCount - lastObserved
+                >= REVEAL_UNOBSERVED_TICKS;
+        boolean moved = scp173.position().distanceToSqr(lastConfirmedPosition)
+                >= REVEAL_TRAVEL_DISTANCE_SQR;
         boolean suddenClose = distanceSqr <= CLOSE_REVEAL_DISTANCE_SQR
                 && (player.tickCount - lastClose >= REVEAL_UNOBSERVED_TICKS
-                || scp173.position().distanceToSqr(lastClosePosition) >= REVEAL_TRAVEL_DISTANCE_SQR);
-        boolean roll = player.getRandom().nextFloat() < REPEAT_REVEAL_SOUND_CHANCE;
-        return new RevealState((unobserved || suddenClose) && moved && roll, false);
+                || scp173.position().distanceToSqr(lastClosePosition)
+                >= REVEAL_TRAVEL_DISTANCE_SQR);
+        boolean roll = player.getRandom().nextFloat()
+                < REPEAT_REVEAL_SOUND_CHANCE;
+        return new RevealState((unobserved || suddenClose) && moved && roll,
+                false);
     }
 
-    private static boolean isConfirmedVisualThreat(ServerPlayer player, Scp173Entity scp173) {
+    private static boolean isConfirmedVisualThreat(ServerPlayer player,
+            Scp173Entity scp173) {
         return scp173.isActivated() && scp173.isObservedBy(player)
-                && scp173.distanceToSqr(player) <= VISUAL_CONFIRM_DISTANCE_SQR;
+                && scp173.distanceToSqr(player)
+                <= VISUAL_CONFIRM_DISTANCE_SQR;
     }
 
-    private static void updateObservedMemory(ServerPlayer player, Scp173Entity scp173) {
+    private static void updateObservedMemory(ServerPlayer player,
+            Scp173Entity scp173) {
         if (scp173.isObservedBy(player)) {
             ObservationKey key = observationKey(player, scp173);
             LAST_OBSERVED_TICK.put(key, player.tickCount);
@@ -140,7 +210,8 @@ public final class BlinkWatcherAggroEvents {
         }
     }
 
-    private static void updateConfirmedObservedMemory(ServerPlayer player, Scp173Entity scp173) {
+    private static void updateConfirmedObservedMemory(ServerPlayer player,
+            Scp173Entity scp173) {
         if (isConfirmedVisualThreat(player, scp173)) {
             ObservationKey key = observationKey(player, scp173);
             LAST_CONFIRMED_OBSERVED_TICK.put(key, player.tickCount);
@@ -148,41 +219,57 @@ public final class BlinkWatcherAggroEvents {
         }
     }
 
-    private static void updateCloseObservedMemory(ServerPlayer player, Scp173Entity scp173) {
-        if (isConfirmedVisualThreat(player, scp173) && scp173.distanceToSqr(player) <= CLOSE_REVEAL_DISTANCE_SQR) {
+    private static void updateCloseObservedMemory(ServerPlayer player,
+            Scp173Entity scp173) {
+        if (isConfirmedVisualThreat(player, scp173)
+                && scp173.distanceToSqr(player)
+                <= CLOSE_REVEAL_DISTANCE_SQR) {
             ObservationKey key = observationKey(player, scp173);
             LAST_CLOSE_OBSERVED_TICK.put(key, player.tickCount);
             LAST_CLOSE_OBSERVED_POSITION.put(key, scp173.position());
         }
     }
 
-    private static boolean wasObservedBefore(ServerPlayer player, Scp173Entity scp173) {
-        return LAST_OBSERVED_TICK.containsKey(observationKey(player, scp173));
+    private static boolean wasObservedBefore(ServerPlayer player,
+            Scp173Entity scp173) {
+        return LAST_OBSERVED_TICK.containsKey(
+                observationKey(player, scp173));
     }
 
-    private static ObservationKey observationKey(ServerPlayer player, Scp173Entity scp173) {
+    private static ObservationKey observationKey(ServerPlayer player,
+            Scp173Entity scp173) {
         return new ObservationKey(player.getUUID(), scp173.getUUID());
     }
 
-    private static boolean shouldKeepHudForParanoia(ServerPlayer player, UUID id) {
-        return player.tickCount - LAST_THREAT_TICK.getOrDefault(id, -HUD_DISENGAGE_DELAY_TICKS) <= HUD_DISENGAGE_DELAY_TICKS;
+    private static boolean shouldKeepHudForParanoia(ServerPlayer player,
+            UUID id) {
+        return player.tickCount - LAST_THREAT_TICK.getOrDefault(id,
+                -HUD_DISENGAGE_DELAY_TICKS) <= HUD_DISENGAGE_DELAY_TICKS;
     }
 
-    private static boolean maybeSendRevealSound(ServerPlayer player, UUID id, boolean ignoreCooldown) {
-        int last = LAST_REVEAL_SOUND_TICK.getOrDefault(id, -REVEAL_SOUND_COOLDOWN_TICKS);
-        if (!ignoreCooldown && player.tickCount - last < REVEAL_SOUND_COOLDOWN_TICKS) return false;
+    private static boolean maybeSendRevealSound(ServerPlayer player, UUID id,
+            boolean ignoreCooldown) {
+        int last = LAST_REVEAL_SOUND_TICK.getOrDefault(id,
+                -REVEAL_SOUND_COOLDOWN_TICKS);
+        if (!ignoreCooldown && player.tickCount - last
+                < REVEAL_SOUND_COOLDOWN_TICKS) {
+            return false;
+        }
         LAST_REVEAL_SOUND_TICK.put(id, player.tickCount);
         ScpEntityNetwork.playScare(player);
         return true;
     }
 
-    private record ObservationKey(UUID playerId, UUID scpId) { }
+    private record ObservationKey(UUID playerId, UUID scpId) {
+    }
 
     private record RevealState(boolean shouldPlay, boolean forceSound) {
         private static final RevealState NONE = new RevealState(false, false);
     }
 
-    private record ThreatState(boolean active, boolean closeObservedReveal, boolean hasWatcher, boolean forceRevealSound) {
-        private static final ThreatState INACTIVE = new ThreatState(false, false, false, false);
+    private record ThreatState(boolean active, boolean closeObservedReveal,
+            boolean hasWatcher, boolean forceRevealSound) {
+        private static final ThreatState INACTIVE = new ThreatState(false,
+                false, false, false);
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/network/BlinkInputStatePacket.java
+++ b/src/main/java/net/mcreator/scpadditions/network/BlinkInputStatePacket.java
@@ -3,6 +3,7 @@ package net.mcreator.scpadditions.network;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.network.NetworkEvent;
+import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
 import net.mcreator.scpadditions.entity.BlinkServerState;
 import net.mcreator.scpadditions.entity.Scp173Entity;
 
@@ -16,20 +17,37 @@ public final class BlinkInputStatePacket {
         this.closed = closed;
         this.manual = manual;
     }
-    public static void encode(BlinkInputStatePacket message, FriendlyByteBuf buffer) {
+
+    public static void encode(BlinkInputStatePacket message,
+            FriendlyByteBuf buffer) {
         buffer.writeBoolean(message.closed);
         buffer.writeBoolean(message.manual);
     }
+
     public static BlinkInputStatePacket decode(FriendlyByteBuf buffer) {
-        return new BlinkInputStatePacket(buffer.readBoolean(), buffer.readBoolean());
+        return new BlinkInputStatePacket(buffer.readBoolean(),
+                buffer.readBoolean());
     }
-    public static void handle(BlinkInputStatePacket message, Supplier<NetworkEvent.Context> supplier) {
+
+    public static void handle(BlinkInputStatePacket message,
+            Supplier<NetworkEvent.Context> supplier) {
         NetworkEvent.Context context = supplier.get();
         context.enqueueWork(() -> {
             ServerPlayer player = context.getSender();
-            if (player != null) {
-                boolean changed = BlinkServerState.setBlinkClosed(player, message.closed, message.manual);
-                if (changed) Scp173Entity.reactToBlinkState(player, message.closed, message.manual);
+            if (player == null) return;
+
+            boolean allowed = ScpAdditionsModulesConfig.get().blink.enabled
+                    && ScpAdditionsModulesConfig.get().scp173.enabled
+                    && !player.isCreative() && !player.isSpectator();
+            boolean closed = allowed && message.closed;
+            boolean manual = closed && message.manual;
+            boolean changed = BlinkServerState.setBlinkClosed(player, closed,
+                    manual);
+            if (changed) {
+                Scp173Entity.reactToBlinkState(player, closed, manual);
+            }
+            if (!allowed && message.closed) {
+                ScpEntityNetwork.setBlinkActive(player, false);
             }
         });
         context.setPacketHandled(true);

--- a/src/main/java/net/mcreator/scpadditions/network/BlinkStatePacket.java
+++ b/src/main/java/net/mcreator/scpadditions/network/BlinkStatePacket.java
@@ -1,5 +1,6 @@
 package net.mcreator.scpadditions.network;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.DistExecutor;
@@ -10,12 +11,32 @@ import java.util.function.Supplier;
 
 public final class BlinkStatePacket {
     private final boolean active;
-    public BlinkStatePacket(boolean active) { this.active = active; }
-    public static void encode(BlinkStatePacket message, FriendlyByteBuf buffer) { buffer.writeBoolean(message.active); }
-    public static BlinkStatePacket decode(FriendlyByteBuf buffer) { return new BlinkStatePacket(buffer.readBoolean()); }
-    public static void handle(BlinkStatePacket message, Supplier<NetworkEvent.Context> supplier) {
+
+    public BlinkStatePacket(boolean active) {
+        this.active = active;
+    }
+
+    public static void encode(BlinkStatePacket message,
+            FriendlyByteBuf buffer) {
+        buffer.writeBoolean(message.active);
+    }
+
+    public static BlinkStatePacket decode(FriendlyByteBuf buffer) {
+        return new BlinkStatePacket(buffer.readBoolean());
+    }
+
+    public static void handle(BlinkStatePacket message,
+            Supplier<NetworkEvent.Context> supplier) {
         NetworkEvent.Context context = supplier.get();
-        context.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> BlinkClient.setActive(message.active)));
+        context.enqueueWork(() -> DistExecutor.unsafeRunWhenOn(Dist.CLIENT,
+                () -> () -> {
+                    Minecraft minecraft = Minecraft.getInstance();
+                    boolean allowed = message.active
+                            && minecraft.player != null
+                            && !minecraft.player.isCreative()
+                            && !minecraft.player.isSpectator();
+                    BlinkClient.setActive(allowed);
+                }));
         context.setPacketHandled(true);
     }
 }


### PR DESCRIPTION
## Summary
- makes configured SCP-914 recipes prefer a complete intake match instead of the first matching JSON entry
- compares explicit and inferred crafting transformations, allowing a more complete multi-item recipe to beat a one-item transformation while explicit recipes still win ties
- preserves the established behavior where a started SCP-914 cycle consumes the complete intake
- makes the server enforce both `blink.enabled` and `scp_173.enabled` before activating or accepting Blink state
- clears Blink threat memory and closed-eye state when the player enters Creative/Spectator or the module is disabled
- rejects stale server activation packets on Creative/Spectator clients
- rejects manual/automatic Blink input sent while the system is unavailable

The SCP-914 report was intermittent because recipe order and the exact intake arrangement determined which valid recipe won. The Blink client already contained Creative checks, but server activation did not check the Blink module, which could keep dedicated-server clients active after the host disabled it.