### PR TITLE
Refine SCP threat behavior and soundtrack priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@
 
 ## Audio and presentation
 
-- Reintroduced the world-entry sound and added a General & Modules option to disable it.
+- Reintroduced the world-entry sound and added a General & Modules option to disable it;
+- Made SCP-1176's music and SCP-106's chase soundtrack immediately stop vanilla background music and keep it suppressed until the complete active SCP soundtrack, including the chase ending cue, has finished.
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 
 ## SCP-173
 
-- Reduced SCP-173's rendered height to approximately two blocks.
+- Reduced SCP-173's rendered height to approximately two blocks;
+- Prevented SCP-173 from scraping and shuffling against closed doors when no complete path to its target exists; it now waits silently and resumes as soon as a route becomes available.
 
 ## SCP-131
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Corrosion left by SCP-106 continuously slows Survival players who walk over it;
 - SCP-106 can phase through solid blocks, moving more slowly while inside them and leaving temporary portals on the surfaces it enters and exits;
 - If the player creates too much distance, SCP-106 can disappear and re-emerge ahead of the player's path;
+- Made SCP-106's legs commit more clearly to its close-range lunge and stopped the entity from sliding forward during the attack's recovery;
+- Hid SCP-106 only during the brief position interpolation between sinking and re-emerging, preventing its ambush relocation from appearing as a very fast straight-line movement;
 - Added phasing sounds and chase soundtrack;
 - Tesla Gates repel SCP-106 instead of killing it, forcing it to sink away and preventing the next two natural spawn checks;
 - Hunts can end quickly or continue for several minutes depending on how long SCP-106 remains interested in the target; players can create distance, but cannot simply despawn or lose SCP-106 before the hunt ends.
@@ -29,6 +31,7 @@
 
 - Added a processing-power system that limits how often SCP-079 can interfere with the facility and forces it to choose its actions more carefully;
 - SCP-079 now reacts differently depending on the threat chasing the player, using doors, temporary access denial, and nearby Tesla Gates when useful;
+- Made SCP-079 recognize SCP-106 hunts across the creature's short repositioning window and more reliably close or briefly lock a useful door ahead without bypassing processing costs or per-door cooldowns;
 - Improved its SCP-012 trap behavior so repeated interference becomes increasingly difficult and less worthwhile;
 - SCP-079 can now close and lock an open door to separate following SCP-131 instances when SCP-173 is waiting ahead;
 - SCP-079 can spend processing power continuously to keep a useful door locked for longer, releasing it when the strategy is no longer useful or it cannot afford the upkeep;
@@ -418,4 +421,3 @@
 * Added first-run copying of bundled default configuration files;
 * Existing local configuration files are not overwritten automatically;
 * Kept SCP-294 currency handling exclusive to either the custom inventory or vanilla inventory, depending on the selected inventory mode;
-

--- a/src/main/java/net/mcreator/scpadditions/client/ModMusicExclusivityClient.java
+++ b/src/main/java/net/mcreator/scpadditions/client/ModMusicExclusivityClient.java
@@ -1,0 +1,33 @@
+package net.mcreator.scpadditions.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.mcreator.scpadditions.ScpAdditionsMod;
+
+/** Keeps vanilla background music out of active SCP soundtrack sequences. */
+@Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID, value = Dist.CLIENT)
+public final class ModMusicExclusivityClient {
+    private ModMusicExclusivityClient() {
+    }
+
+    public static void stopVanillaMusicNow() {
+        Minecraft.getInstance().getMusicManager().stopPlaying();
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END
+                || !hasActiveModMusic()) {
+            return;
+        }
+        stopVanillaMusicNow();
+    }
+
+    private static boolean hasActiveModMusic() {
+        return Scp1176MusicClient.isPlaying()
+                || Scp106ChaseAudioClient.isPlaying();
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/client/Scp106ChaseAudioClient.java
+++ b/src/main/java/net/mcreator/scpadditions/client/Scp106ChaseAudioClient.java
@@ -11,6 +11,7 @@ import net.mcreator.scpadditions.ScpAdditionsMod;
 @Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID, value = Dist.CLIENT)
 public final class Scp106ChaseAudioClient {
     private static Scp106ChaseSound chase;
+    private static int ticksSinceStart;
 
     private Scp106ChaseAudioClient() {
     }
@@ -22,8 +23,10 @@ public final class Scp106ChaseAudioClient {
                 && !chase.isFadingOut()) {
             return;
         }
-        if (chase != null) minecraft.getSoundManager().stop(chase);
+        if (chase != null) chase.stopImmediately();
         chase = new Scp106ChaseSound();
+        ticksSinceStart = 0;
+        ModMusicExclusivityClient.stopVanillaMusicNow();
         minecraft.getSoundManager().play(chase);
     }
 
@@ -31,10 +34,26 @@ public final class Scp106ChaseAudioClient {
         if (chase != null) chase.beginFadeOut(true);
     }
 
+    public static boolean isPlaying() {
+        return chase != null;
+    }
+
     @SubscribeEvent
     public static void onClientTick(TickEvent.ClientTickEvent event) {
         if (event.phase != TickEvent.Phase.END || chase == null) return;
+
         Minecraft minecraft = Minecraft.getInstance();
-        if (!minecraft.getSoundManager().isActive(chase)) chase = null;
+        if (minecraft.player == null || minecraft.level == null) {
+            chase.stopImmediately();
+            chase = null;
+            ticksSinceStart = 0;
+            return;
+        }
+
+        ticksSinceStart++;
+        if (ticksSinceStart > 1 && !chase.hasActiveAudio()) {
+            chase = null;
+            ticksSinceStart = 0;
+        }
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/client/Scp106ChaseSound.java
+++ b/src/main/java/net/mcreator/scpadditions/client/Scp106ChaseSound.java
@@ -21,6 +21,7 @@ public final class Scp106ChaseSound extends AbstractTickableSoundInstance {
     private int fadeTicksRemaining = -1;
     private boolean playStopCue;
     private boolean stopCuePlayed;
+    private SimpleSoundInstance stopCue;
 
     public Scp106ChaseSound() {
         super(Scp106Sounds.CHASE.get(), SoundSource.MUSIC,
@@ -50,9 +51,9 @@ public final class Scp106ChaseSound extends AbstractTickableSoundInstance {
         if (playStopCue && !stopCuePlayed
                 && fadeTicksRemaining <= STOP_CUE_LEAD_TICKS
                 && minecraft.player != null && minecraft.level != null) {
-            minecraft.getSoundManager().play(
-                    SimpleSoundInstance.forUI(Scp106Sounds.STOP.get(),
-                            1.0F, STOP_CUE_VOLUME));
+            stopCue = SimpleSoundInstance.forUI(Scp106Sounds.STOP.get(),
+                    1.0F, STOP_CUE_VOLUME);
+            minecraft.getSoundManager().play(stopCue);
             stopCuePlayed = true;
         }
         if (fadeTicksRemaining == 0) {
@@ -82,5 +83,20 @@ public final class Scp106ChaseSound extends AbstractTickableSoundInstance {
 
     public boolean isFadingOut() {
         return fadeTicksRemaining >= 0;
+    }
+
+    public boolean hasActiveAudio() {
+        Minecraft minecraft = Minecraft.getInstance();
+        return minecraft.getSoundManager().isActive(this)
+                || (stopCue != null
+                && minecraft.getSoundManager().isActive(stopCue));
+    }
+
+    public void stopImmediately() {
+        Minecraft minecraft = Minecraft.getInstance();
+        minecraft.getSoundManager().stop(this);
+        if (stopCue != null) {
+            minecraft.getSoundManager().stop(stopCue);
+        }
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/client/Scp1176MusicClient.java
+++ b/src/main/java/net/mcreator/scpadditions/client/Scp1176MusicClient.java
@@ -7,6 +7,7 @@ import net.mcreator.scpadditions.init.ScpAdditionsModSounds;
 /** Owns the head-relative SCP-1176 music so it can be stopped on death or disconnect. */
 public final class Scp1176MusicClient {
     private static SimpleSoundInstance activeMusic;
+    private static int ticksSinceStart;
 
     private Scp1176MusicClient() {
     }
@@ -16,6 +17,8 @@ public final class Scp1176MusicClient {
 
         Minecraft minecraft = Minecraft.getInstance();
         activeMusic = SimpleSoundInstance.forUI(ScpAdditionsModSounds.SCP1176.get(), 1.0F, 1.0F);
+        ticksSinceStart = 0;
+        ModMusicExclusivityClient.stopVanillaMusicNow();
         minecraft.getSoundManager().play(activeMusic);
     }
 
@@ -25,13 +28,26 @@ public final class Scp1176MusicClient {
         Minecraft minecraft = Minecraft.getInstance();
         if (minecraft.player == null || !minecraft.player.isAlive()) {
             stop();
+            return;
+        }
+
+        ticksSinceStart++;
+        if (ticksSinceStart > 1
+                && !minecraft.getSoundManager().isActive(activeMusic)) {
+            activeMusic = null;
+            ticksSinceStart = 0;
         }
     }
 
-    public static void stop() {
-        if (activeMusic == null) return;
+    public static boolean isPlaying() {
+        return activeMusic != null;
+    }
 
-        Minecraft.getInstance().getSoundManager().stop(activeMusic);
+    public static void stop() {
+        if (activeMusic != null) {
+            Minecraft.getInstance().getSoundManager().stop(activeMusic);
+        }
         activeMusic = null;
+        ticksSinceStart = 0;
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/entity/Scp106Entity.java
+++ b/src/main/java/net/mcreator/scpadditions/entity/Scp106Entity.java
@@ -85,6 +85,8 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
     private static final double RANGED_MAX_DISTANCE_SQR = 11.5D * 11.5D;
     private static final int PATH_REFRESH_INTERVAL = 10;
     private static final int ATTACK_HIT_TICK = 15;
+    private static final int ATTACK_PURSUIT_END_TICK =
+            ATTACK_HIT_TICK + 3;
     private static final int ATTACK_DURATION_TICKS = 34;
     private static final int WITHER_DURATION_TICKS = 5 * 20;
     private static final int TRAIL_PARTICLE_INTERVAL = 5;
@@ -107,6 +109,7 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
     private static final int RANGED_COOLDOWN_TICKS = 14 * 20;
     private static final int RANGED_ABORT_COOLDOWN_TICKS = 4 * 20;
     private static final int RANGED_HAND_PARTICLE_START_TICK = 33;
+    private static final int RELOCATION_HIDE_TICKS = 5;
     private static final int TESLA_SUPPRESSION_TICKS = 10 * 60 * 20;
 
     private static final RawAnimation IDLE_ANIMATION =
@@ -140,6 +143,7 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
     private int phaseEntryGraceTicks;
     private int phaseExitClearTicks;
     private int ambushCooldownTicks;
+    private int relocationHiddenTicks;
     private UUID huntedPlayerId;
     private boolean vanishForDespawn;
     private Vec3 rangedLockedDirection = Vec3.ZERO;
@@ -179,6 +183,7 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
         tag.putInt("Scp106AmbushCooldown", ambushCooldownTicks);
         tag.putInt("Scp106RangedCooldown", rangedCooldownTicks);
         tag.putInt("Scp106FarDistanceTicks", farDistanceTicks);
+        tag.putInt("Scp106RelocationHiddenTicks", relocationHiddenTicks);
         tag.putBoolean("Scp106VanishForDespawn", vanishForDespawn);
         tag.putFloat("Scp106EmergenceYaw", emergenceYaw);
         if (huntedPlayerId != null) {
@@ -201,6 +206,8 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
                 tag.getInt("Scp106RangedCooldown"));
         farDistanceTicks = Math.max(0,
                 tag.getInt("Scp106FarDistanceTicks"));
+        relocationHiddenTicks = Math.max(0,
+                tag.getInt("Scp106RelocationHiddenTicks"));
         vanishForDespawn = tag.getBoolean("Scp106VanishForDespawn");
         emergenceYaw = tag.contains("Scp106EmergenceYaw")
                 ? tag.getFloat("Scp106EmergenceYaw") : getYRot();
@@ -208,6 +215,10 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
                 ? tag.getUUID("Scp106HuntedPlayer") : null;
         entityData.set(ATTACKING, false);
         entityData.set(RANGED_ATTACKING, false);
+        boolean emerging = getEncounterState() == EMERGING_GROUND
+                || getEncounterState() == EMERGING_WALL;
+        if (!emerging) relocationHiddenTicks = 0;
+        setInvisible(emerging && relocationHiddenTicks > 0);
     }
 
     private void applyCurrentMovementSpeed() {
@@ -300,9 +311,12 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
         getNavigation().stop();
         freezeTransitionMovement();
         lockEmergenceRotation();
+        tickRelocationVisibility();
         if (stateTicks > 0) stateTicks--;
         if (stateTicks > 0) return;
 
+        relocationHiddenTicks = 0;
+        setInvisible(false);
         setEncounterState(HUNTING);
         noPhysics = false;
         setNoGravity(false);
@@ -440,7 +454,12 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
 
     private void tickAttack(LivingEntity target) {
         getLookControl().setLookAt(target, 45.0F, 25.0F);
-        pursueDuringAttack(target);
+        if (attackTicks <= ATTACK_PURSUIT_END_TICK) {
+            pursueDuringAttack(target);
+        } else {
+            getNavigation().stop();
+            stopHorizontalMovement();
+        }
         attackTicks++;
 
         if (attackTicks == ATTACK_HIT_TICK
@@ -545,6 +564,8 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
     private void beginVanish(boolean despawnAfterward) {
         if (getEncounterState() == VANISHING) return;
         vanishForDespawn = despawnAfterward;
+        relocationHiddenTicks = 0;
+        setInvisible(false);
         stateTicks = VANISH_TICKS;
         setEncounterState(VANISHING);
         entityData.set(ATTACKING, false);
@@ -589,17 +610,24 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
             return;
         }
 
+        setInvisible(true);
         moveTo(placement.position().x, placement.position().y,
                 placement.position().z, placement.yaw(), 0.0F);
         setYBodyRot(placement.yaw());
         setYHeadRot(placement.yaw());
-        startEmergence(placement.emergence());
+        startEmergence(placement.emergence(), RELOCATION_HIDE_TICKS);
         ambushCooldownTicks = AMBUSH_COOLDOWN_TICKS;
         farDistanceTicks = 0;
     }
 
     private void startEmergence(Emergence emergence) {
+        startEmergence(emergence, 0);
+    }
+
+    private void startEmergence(Emergence emergence, int hiddenTicks) {
         vanishForDespawn = false;
+        relocationHiddenTicks = Math.max(0, hiddenTicks);
+        setInvisible(relocationHiddenTicks > 0);
         emergenceYaw = getYRot();
         if (emergence == Emergence.GROUND) alignGroundEmergencePosition();
         entityData.set(ATTACKING, false);
@@ -616,6 +644,15 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
         setNoGravity(true);
         getNavigation().stop();
         freezeTransitionMovement();
+    }
+
+    private void tickRelocationVisibility() {
+        if (relocationHiddenTicks <= 0) return;
+        setInvisible(true);
+        relocationHiddenTicks--;
+        if (relocationHiddenTicks == 0) {
+            setInvisible(false);
+        }
     }
 
     private Player resolveHuntedPlayer() {
@@ -695,6 +732,8 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
     private void idleForCreativeTarget() {
         setEncounterState(HUNTING);
         setTarget(null);
+        relocationHiddenTicks = 0;
+        setInvisible(false);
         entityData.set(ATTACKING, false);
         attackTicks = 0;
         cancelRangedAttack();

--- a/src/main/java/net/mcreator/scpadditions/entity/Scp173Entity.java
+++ b/src/main/java/net/mcreator/scpadditions/entity/Scp173Entity.java
@@ -772,8 +772,6 @@ public class Scp173Entity extends BlinkWatcherEntity {
             trySnapAttack(target);
             return;
         }
-        entityData.set(SCRAPING, true);
-        faceTarget(target);
         Player blinkPlayer = target instanceof Player player ? player : null;
         boolean blinkClosed = blinkPlayer != null && BlinkServerState.isBlinkClosed(blinkPlayer);
         boolean manualBlink = blinkClosed && BlinkServerState.isManualBlink(blinkPlayer);
@@ -788,10 +786,15 @@ public class Scp173Entity extends BlinkWatcherEntity {
             }
         }
         Vec3 step = chooseChaseStep(target, horizontal, distance, maxStep);
-        if (step.lengthSqr() > 0.000001D) {
-            snapMove(step);
-            if (blinkClosed && !manualBlink) consumeAutomaticBlinkTravel(blinkPlayer, step.length());
+        if (step.lengthSqr() <= 0.000001D) {
+            stopAndLock(preTickPose);
+            return;
         }
+
+        entityData.set(SCRAPING, true);
+        faceTarget(target);
+        snapMove(step);
+        if (blinkClosed && !manualBlink) consumeAutomaticBlinkTravel(blinkPlayer, step.length());
         getNavigation().stop();
         applyHeavyWaterSinking();
         hardStopLocalMovement();
@@ -812,7 +815,8 @@ public class Scp173Entity extends BlinkWatcherEntity {
         Vec3 directStep = directHorizontal.scale(1.0D / distance).scale(stepDistance);
         if (canMoveBy(directStep)) { getNavigation().stop(); return directStep; }
         Vec3 pathStep = pathStepToward(target, stepDistance);
-        if (pathStep.lengthSqr() > 0.000001D && canMoveBy(pathStep)) return pathStep;
+        if (pathStep.lengthSqr() <= 0.000001D) return Vec3.ZERO;
+        if (canMoveBy(pathStep)) return pathStep;
         return bestFallbackStep(target, directHorizontal, stepDistance);
     }
 
@@ -820,7 +824,10 @@ public class Scp173Entity extends BlinkWatcherEntity {
         // The path is a direction source only. Do not install it into active
         // navigation, which would add vanilla motion on the following tick.
         Path path = getNavigation().createPath(target, 0);
-        if (path == null || path.isDone()) return Vec3.ZERO;
+        // A partial path that merely ends at a closed door is not useful.
+        // Keep the target so facility control can still reopen the route, but
+        // wait silently instead of improvising side steps against the obstacle.
+        if (path == null || path.isDone() || !path.canReach()) return Vec3.ZERO;
         Vec3 next = path.getNextEntityPos(this);
         Vec3 horizontal = new Vec3(next.x - getX(), 0.0D, next.z - getZ());
         if (horizontal.lengthSqr() <= PATH_NODE_REACHED_DISTANCE_SQR) {

--- a/src/main/java/net/mcreator/scpadditions/facility/Scp079FacilityThreatEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/Scp079FacilityThreatEvents.java
@@ -11,6 +11,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Mob;
 import net.mcreator.scpadditions.entity.AbstractScp131Entity;
+import net.mcreator.scpadditions.entity.Scp106Entity;
 import net.mcreator.scpadditions.entity.Scp173Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -50,6 +51,7 @@ public final class Scp079FacilityThreatEvents {
     private static final int FLEE_DOOR_RADIUS = 7;
     private static final int PURSUER_DOOR_RADIUS = 6;
     private static final int PURSUER_SEARCH_RADIUS = 14;
+    private static final int SCP_106_PURSUER_SEARCH_RADIUS = 22;
     private static final int DOOR_REUSE_TICKS = 100;
     private static final int LOCKED_DOOR_REUSE_TICKS = 140;
     private static final int SCP_131_SEPARATION_RADIUS = 16;
@@ -98,9 +100,20 @@ public final class Scp079FacilityThreatEvents {
             return;
         }
 
-        List<Mob> pursuers = level.getEntitiesOfClass(Mob.class,
+        List<Mob> pursuers = new ArrayList<>(level.getEntitiesOfClass(
+                Mob.class,
                 player.getBoundingBox().inflate(PURSUER_SEARCH_RADIUS),
-                mob -> mob.isAlive() && mob.getTarget() == player);
+                mob -> mob.isAlive() && mob.getTarget() == player));
+        for (Scp106Entity scp106 : level.getEntitiesOfClass(
+                Scp106Entity.class,
+                player.getBoundingBox().inflate(
+                        SCP_106_PURSUER_SEARCH_RADIUS),
+                entity -> entity.isAlive()
+                        && entity.getTarget() == player)) {
+            if (!pursuers.contains(scp106)) {
+                pursuers.add(scp106);
+            }
+        }
         Mob pursuer = pursuers.stream()
                 .min(Comparator.comparingDouble(player::distanceToSqr))
                 .orElse(null);
@@ -751,7 +764,7 @@ public final class Scp079FacilityThreatEvents {
                 case "scp_173" -> new ThreatProfile(true, true,
                         0.36F, 0.22F, 0.06F, 40, 100, 8.0D);
                 case "scp_106" -> new ThreatProfile(false, true,
-                        0.0F, 0.24F, 0.04F, 35, 80, 10.0D);
+                        0.0F, 0.32F, 0.12F, 35, 80, 6.0D);
                 default -> DEFAULT;
             };
         }

--- a/src/main/resources/assets/scp_additions/animations/entity/scp106.animation.json
+++ b/src/main/resources/assets/scp_additions/animations/entity/scp106.animation.json
@@ -1408,37 +1408,37 @@
 						},
 						"0.22": {
 							"post": {
-								"vector": [8, 0, -5]
+								"vector": [12, 0, -5]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"0.48": {
 							"post": {
-								"vector": [14, 0, -5]
+								"vector": [24, 0, -5]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"0.7": {
 							"post": {
-								"vector": [-8, 0, -5]
+								"vector": [-14, 0, -5]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"0.86": {
 							"post": {
-								"vector": [-12, 0, -4]
+								"vector": [-20, 0, -4]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"1.02": {
 							"post": {
-								"vector": [-14, 0, -3]
+								"vector": [-22, 0, -3]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"1.32": {
 							"post": {
-								"vector": [-6, 0, -4]
+								"vector": [-8, 0, -4]
 							},
 							"lerp_mode": "catmullrom"
 						},
@@ -1512,37 +1512,37 @@
 						},
 						"0.22": {
 							"post": {
-								"vector": [-7, 0, 5]
+								"vector": [-10, 0, 5]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"0.48": {
 							"post": {
-								"vector": [-12, 0, 5]
+								"vector": [-20, 0, 5]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"0.7": {
 							"post": {
-								"vector": [12, 0, 4]
+								"vector": [16, 0, 4]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"0.86": {
 							"post": {
-								"vector": [18, 0, 3]
+								"vector": [24, 0, 3]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"1.02": {
 							"post": {
-								"vector": [20, 0, 2]
+								"vector": [26, 0, 2]
 							},
 							"lerp_mode": "catmullrom"
 						},
 						"1.32": {
 							"post": {
-								"vector": [8, 0, 4]
+								"vector": [10, 0, 4]
 							},
 							"lerp_mode": "catmullrom"
 						},


### PR DESCRIPTION
## What changed

- Makes SCP-106's close-range attack leg motion more readable and stops forward pursuit during the recovery portion of the animation.
- Hides SCP-106 for five ticks while the client interpolates its ambush relocation, preventing the entity from visibly streaking in a straight line between the sink and emergence positions.
- Makes SCP-173 reject incomplete routes that end at a closed obstacle, remain still and silent when no complete route exists, and resume as soon as pathfinding finds an available route.
- Keeps SCP-173's target while it waits, preserving SCP-079's ability to recognize the chase and reopen a useful facility door.
- Lets SCP-079 recognize SCP-106 across its short ambush/repositioning window and moderately raises contextual close/deny chances while preserving processing costs, sprint/direction requirements, and per-door cooldowns.
- Makes the SCP-1176 music and SCP-106 chase soundtrack immediately stop vanilla Minecraft background music and continuously suppress new vanilla music until the active SCP soundtrack has fully finished.
- Keeps the SCP-106 music lock through its fade-out and complete `106stop.ogg` ending cue, while SCP-1176 releases it when its actual sound instance ends.
- Updates the 3.0.8 changelog.

## Root causes

- The SCP-106 attack controller played one lunge animation while AI pursuit continued through the complete 34-tick action, producing visible sliding during recovery.
- Server-side SCP-106 `moveTo` relocation was rendered through client interpolation before the emergence settled.
- SCP-173 enabled its `SCRAPING` state before confirming that a movement step was possible, and incomplete paths fell through to improvised lateral steps against the closed door.
- SCP-079 searched for pursuers only within 14 blocks once per second, while SCP-106 can start repositioning after 0.6 seconds beyond 8 blocks; its access-denial profile also required 10 blocks of separation despite that behavior.
- Vanilla's `MusicManager` schedules background music independently from custom sound instances, so starting either SCP soundtrack did not stop an existing vanilla track or prevent another from being scheduled during it.

## Validation

- The current `Build` workflow passed with Java 17/Gradle and uploaded the compiled JAR at head `9128b81897569fb48c58b7ddcce41cb84f6365f6`.
- The `Asset Audit` workflow also completed its full build successfully, then failed in its separate audit step because the workflow calls the missing repository file `scripts/audit_unused_assets.py`; this is unrelated to the changed production files.
- `jq empty src/main/resources/assets/scp_additions/animations/entity/scp106.animation.json` passed for the animation edit.
- Static validation confirmed exact source replacements, balanced Java braces, the complete-path reachability guard, `SCRAPING` activation only after a non-zero movement step, and soundtrack ownership lasting through each relevant sound instance.