### PR TITLE
Add SL1 ceiling blocks and redstone lamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@
 - Added a Screwdriver editor for three compacting, reorderable entries, including per-entry and whole-sign copy/paste memory stored on the tool.
 - Compacted both Facility Sign editors, removed their redundant text previews, aligned character counters with their fields, and matched destructive and confirmation controls to the Configuration Center's red and gold visual language.
 
+## Facility construction
+
+- Added SL1 Ceiling and SL1 Ceiling Alt construction blocks;
+- Added an SL1 ceiling lamp that changes its lower face and emits light while powered by redstone.
+
 ## Accessibility
 
 - Added a dedicated Accessibility screen to the Configuration Center, beginning with a Photosensitive Epilepsy section;

--- a/src/main/java/net/mcreator/scpadditions/facility/UBlocksModule.java
+++ b/src/main/java/net/mcreator/scpadditions/facility/UBlocksModule.java
@@ -21,6 +21,8 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.phys.shapes.CollisionContext;
@@ -65,6 +67,10 @@ public final class UBlocksModule {
     public static final RegistryObject<Block> SL1_WALL_BOT = structure("sl1_wall_bot");
     public static final RegistryObject<Block> SL1_WALL_MID = structure("sl1_wall_mid");
     public static final RegistryObject<Block> SL_1_WALL_TOP = structure("sl_1_wall_top");
+    public static final RegistryObject<Block> SL1_CEILING = structure("sl1_ceiling");
+    public static final RegistryObject<Block> SL1_CEILING_ALT = structure("sl1_ceiling_alt");
+    public static final RegistryObject<Block> SL1_LAMP = registerBlock(
+            "sl1_lamp", RedstoneCeilingLampBlock::new, false);
 
     // Sector 1 directional decoration.
     public static final RegistryObject<Block> SL_1_FLOOR_DETAIL_SMALL = directional(
@@ -185,6 +191,41 @@ public final class UBlocksModule {
         public List<ItemStack> getDrops(BlockState state, LootParams.Builder builder) {
             List<ItemStack> original = super.getDrops(state, builder);
             return original.isEmpty() ? Collections.singletonList(new ItemStack(this)) : original;
+        }
+    }
+
+    private static final class RedstoneCeilingLampBlock extends UBlockStructureBlock {
+        private static final BooleanProperty LIT = BlockStateProperties.LIT;
+
+        private RedstoneCeilingLampBlock() {
+            registerDefaultState(stateDefinition.any().setValue(LIT, false));
+        }
+
+        @Override
+        protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+            builder.add(LIT);
+        }
+
+        @Override
+        public BlockState getStateForPlacement(BlockPlaceContext context) {
+            return defaultBlockState().setValue(LIT,
+                    context.getLevel().hasNeighborSignal(context.getClickedPos()));
+        }
+
+        @Override
+        public void neighborChanged(BlockState state, Level level, BlockPos pos,
+                Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
+            if (!level.isClientSide) {
+                boolean powered = level.hasNeighborSignal(pos);
+                if (state.getValue(LIT) != powered) {
+                    level.setBlock(pos, state.setValue(LIT, powered), Block.UPDATE_ALL);
+                }
+            }
+        }
+
+        @Override
+        public int getLightEmission(BlockState state, BlockGetter level, BlockPos pos) {
+            return state.getValue(LIT) ? 15 : 0;
         }
     }
 

--- a/src/main/resources/assets/scp_ublocks/blockstates/sl1_ceiling.json
+++ b/src/main/resources/assets/scp_ublocks/blockstates/sl1_ceiling.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "scp_ublocks:block/sl1_ceiling"
+    }
+  }
+}

--- a/src/main/resources/assets/scp_ublocks/blockstates/sl1_ceiling_alt.json
+++ b/src/main/resources/assets/scp_ublocks/blockstates/sl1_ceiling_alt.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "scp_ublocks:block/sl1_ceiling_alt"
+    }
+  }
+}

--- a/src/main/resources/assets/scp_ublocks/blockstates/sl1_lamp.json
+++ b/src/main/resources/assets/scp_ublocks/blockstates/sl1_lamp.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "scp_ublocks:block/sl1_lamp_off"
+    },
+    "lit=true": {
+      "model": "scp_ublocks:block/sl1_lamp_on"
+    }
+  }
+}

--- a/src/main/resources/assets/scp_ublocks/lang/en_us.json
+++ b/src/main/resources/assets/scp_ublocks/lang/en_us.json
@@ -18,5 +18,8 @@
   "block.scp_ublocks.sl1_wall_bot": "SL1 Wall Bottom",
   "block.scp_ublocks.sl_2_floor": "SL2 Floor",
   "block.scp_ublocks.sl1_wall_mid": "SL1 Wall Middle",
+  "block.scp_ublocks.sl1_ceiling": "SL1 Ceiling",
+  "block.scp_ublocks.sl1_ceiling_alt": "SL1 Ceiling Alt",
+  "block.scp_ublocks.sl1_lamp": "SL1 Lamp",
   "block.scp_ublocks.vent_open": "Vent"
 }

--- a/src/main/resources/assets/scp_ublocks/models/block/sl1_ceiling.json
+++ b/src/main/resources/assets/scp_ublocks/models/block/sl1_ceiling.json
@@ -1,0 +1,7 @@
+{
+  "parent": "block/cube_all",
+  "textures": {
+    "all": "scp_additions:block/sl1_ceiling"
+  },
+  "render_type": "solid"
+}

--- a/src/main/resources/assets/scp_ublocks/models/block/sl1_ceiling_alt.json
+++ b/src/main/resources/assets/scp_ublocks/models/block/sl1_ceiling_alt.json
@@ -1,0 +1,7 @@
+{
+  "parent": "block/cube_all",
+  "textures": {
+    "all": "scp_additions:block/sl1_ceiling_alt"
+  },
+  "render_type": "solid"
+}

--- a/src/main/resources/assets/scp_ublocks/models/block/sl1_lamp_off.json
+++ b/src/main/resources/assets/scp_ublocks/models/block/sl1_lamp_off.json
@@ -1,0 +1,13 @@
+{
+  "parent": "block/cube",
+  "textures": {
+    "down": "scp_additions:block/sl1_ceiling_lamp_off",
+    "up": "scp_additions:block/sl1_ceiling_lamp_top",
+    "north": "scp_additions:block/sl1_ceiling",
+    "east": "scp_additions:block/sl1_ceiling",
+    "south": "scp_additions:block/sl1_ceiling",
+    "west": "scp_additions:block/sl1_ceiling",
+    "particle": "scp_additions:block/sl1_ceiling"
+  },
+  "render_type": "solid"
+}

--- a/src/main/resources/assets/scp_ublocks/models/block/sl1_lamp_on.json
+++ b/src/main/resources/assets/scp_ublocks/models/block/sl1_lamp_on.json
@@ -1,0 +1,13 @@
+{
+  "parent": "block/cube",
+  "textures": {
+    "down": "scp_additions:block/sl1_ceiling_lamp_on",
+    "up": "scp_additions:block/sl1_ceiling_lamp_top",
+    "north": "scp_additions:block/sl1_ceiling",
+    "east": "scp_additions:block/sl1_ceiling",
+    "south": "scp_additions:block/sl1_ceiling",
+    "west": "scp_additions:block/sl1_ceiling",
+    "particle": "scp_additions:block/sl1_ceiling"
+  },
+  "render_type": "solid"
+}

--- a/src/main/resources/assets/scp_ublocks/models/item/sl1_ceiling.json
+++ b/src/main/resources/assets/scp_ublocks/models/item/sl1_ceiling.json
@@ -1,0 +1,3 @@
+{
+  "parent": "scp_ublocks:block/sl1_ceiling"
+}

--- a/src/main/resources/assets/scp_ublocks/models/item/sl1_ceiling_alt.json
+++ b/src/main/resources/assets/scp_ublocks/models/item/sl1_ceiling_alt.json
@@ -1,0 +1,3 @@
+{
+  "parent": "scp_ublocks:block/sl1_ceiling_alt"
+}

--- a/src/main/resources/assets/scp_ublocks/models/item/sl1_lamp.json
+++ b/src/main/resources/assets/scp_ublocks/models/item/sl1_lamp.json
@@ -1,0 +1,3 @@
+{
+  "parent": "scp_ublocks:block/sl1_lamp_off"
+}


### PR DESCRIPTION
Adds SL1 Ceiling, SL1 Ceiling Alt, and a redstone-reactive SL1 Lamp to the facility building set.

The lamp uses the SL1 ceiling texture on its sides, a dedicated top texture, and switches its bottom texture and light emission when powered. All three blocks are placed with the other SL1 construction blocks in the creative tab.

Validation before merge:
- JSON resources parsed successfully
- static diff checks passed
- GitHub Actions Forge Build required