### PR TITLE
Add optional client rendering test runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,11 +54,35 @@ repositories {
         name = 'GeckoLib'
         url = 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/'
     }
+
+    // Client-side test dependencies are resolved from Modrinth without being
+    // compiled into or bundled with the public SCP Additions artifact.
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'Modrinth'
+                url = 'https://api.modrinth.com/maven'
+            }
+        }
+        forRepositories(fg.repository)
+        filter {
+            includeGroup 'maven.modrinth'
+        }
+    }
 }
 
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.4.10'
     implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.20.1:4.4.9')
+
+    // Optional client runtime used by runClient to validate emissive textures,
+    // PBR materials, shaders and custom player/entity rendering. These are not
+    // transitive requirements for users of SCP Additions.
+    runtimeOnly fg.deobf('maven.modrinth:HFlxNpln:wBmYGKE8') // MoreMcmeta 4.5.1
+    runtimeOnly fg.deobf('maven.modrinth:oQ0dIGZg:rkJ3fswP') // MoreMcmeta Emissive 2.0.4
+    runtimeOnly fg.deobf('maven.modrinth:oaG6aa1j:u7GegV7U') // Kleider's Custom Renderer 7.4.1
+    runtimeOnly fg.deobf('maven.modrinth:sk9rgfiA:UTbfe5d1') // Embeddium 0.3.31
+    runtimeOnly fg.deobf('maven.modrinth:GchcoXML:iQ1SwGc3') // Oculus 1.8.0
 }
 
 processResources {


### PR DESCRIPTION
Adds MoreMcmeta, MoreMcmeta Emissive Textures, Kleider's Custom Renderer API, Embeddium, and Oculus as `runtimeOnly` dependencies for the Forge 1.20.1 `runClient` development environment.

These dependencies are resolved from Modrinth and are not compiled into, bundled with, or declared as required dependencies of SCP Additions.