### PR TITLE
Fix MoreMcmeta dev runtime remapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,28 +82,36 @@ repositories {
 // mappings and crashing runClient with NoSuchMethodError. Prepare a dev-only
 // copy of the core without JarJar contents and remap every extracted plugin as
 // its own dependency.
-configurations {
-    moreMcmetaBundle
-}
-
-dependencies {
-    moreMcmetaBundle 'maven.modrinth:HFlxNpln:1Gk4ti96' // MoreMcmeta 4.5.2
-}
-
 def moreMcmetaDevDir = layout.buildDirectory.dir('moremcmeta-dev-runtime').get().asFile
-def moreMcmetaBundleJar = configurations.moreMcmetaBundle.singleFile
+def moreMcmetaBundleJar = new File(moreMcmetaDevDir, 'moremcmeta-4.5.2-source.jar')
 def moreMcmetaCoreJar = new File(moreMcmetaDevDir, 'moremcmeta-core-dev.jar')
 def moreMcmetaPluginDir = new File(moreMcmetaDevDir, 'plugins')
-def moreMcmetaStamp = new File(moreMcmetaDevDir, '.source-sha1')
+def moreMcmetaExpectedSha1 = '6046753a29d6963ad2a9c557b557bd7a2d793354'
+def moreMcmetaDownloadUrl =
+        'https://cdn.modrinth.com/data/HFlxNpln/versions/1Gk4ti96/moremcmeta-1.20.1-4.5.2-forge.jar'
+
+if (!moreMcmetaBundleJar.exists()) {
+    moreMcmetaBundleJar.parentFile.mkdirs()
+    new URL(moreMcmetaDownloadUrl).withInputStream { input ->
+        moreMcmetaBundleJar.withOutputStream { output -> output << input }
+    }
+}
+
 def moreMcmetaSourceSha1 = java.security.MessageDigest.getInstance('SHA-1')
         .digest(moreMcmetaBundleJar.bytes)
         .encodeHex()
         .toString()
+if (moreMcmetaSourceSha1 != moreMcmetaExpectedSha1) {
+    project.delete(moreMcmetaBundleJar)
+    throw new GradleException("MoreMcmeta download checksum mismatch: ${moreMcmetaSourceSha1}")
+}
 
+def moreMcmetaStamp = new File(moreMcmetaDevDir, '.prepared-source-sha1')
 if (!moreMcmetaStamp.exists()
         || moreMcmetaStamp.getText('UTF-8').trim() != moreMcmetaSourceSha1
         || !moreMcmetaCoreJar.exists()) {
-    project.delete(moreMcmetaDevDir)
+    project.delete(moreMcmetaCoreJar)
+    project.delete(moreMcmetaPluginDir)
     moreMcmetaPluginDir.mkdirs()
 
     project.copy {

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,53 @@ repositories {
     }
 }
 
+// MoreMcmeta bundles five Forge mods inside its public JAR. ForgeGradle only
+// remaps the outer artifact, leaving those nested plugins in production (SRG)
+// mappings and crashing runClient with NoSuchMethodError. Prepare a dev-only
+// copy of the core without JarJar contents and remap every extracted plugin as
+// its own dependency.
+configurations {
+    moreMcmetaBundle
+}
+
+dependencies {
+    moreMcmetaBundle 'maven.modrinth:HFlxNpln:1Gk4ti96' // MoreMcmeta 4.5.2
+}
+
+def moreMcmetaDevDir = layout.buildDirectory.dir('moremcmeta-dev-runtime').get().asFile
+def moreMcmetaBundleJar = configurations.moreMcmetaBundle.singleFile
+def moreMcmetaCoreJar = new File(moreMcmetaDevDir, 'moremcmeta-core.jar')
+def moreMcmetaPluginDir = new File(moreMcmetaDevDir, 'plugins')
+def moreMcmetaStamp = new File(moreMcmetaDevDir, '.source-sha1')
+def moreMcmetaSourceSha1 = java.security.MessageDigest.getInstance('SHA-1')
+        .digest(moreMcmetaBundleJar.bytes)
+        .encodeHex()
+        .toString()
+
+if (!moreMcmetaStamp.exists()
+        || moreMcmetaStamp.getText('UTF-8').trim() != moreMcmetaSourceSha1
+        || !moreMcmetaCoreJar.exists()) {
+    project.delete(moreMcmetaDevDir)
+    moreMcmetaPluginDir.mkdirs()
+
+    project.copy {
+        from zipTree(moreMcmetaBundleJar)
+        include 'META-INF/jars/*.jar'
+        eachFile { details -> details.path = details.name }
+        includeEmptyDirs = false
+        into moreMcmetaPluginDir
+    }
+
+    ant.zip(destfile: moreMcmetaCoreJar) {
+        zipfileset(src: moreMcmetaBundleJar) {
+            exclude(name: 'META-INF/jars/**')
+            exclude(name: 'META-INF/jarjar/**')
+        }
+    }
+
+    moreMcmetaStamp.setText(moreMcmetaSourceSha1 + System.lineSeparator(), 'UTF-8')
+}
+
 dependencies {
     minecraft 'net.minecraftforge:forge:1.20.1-47.4.10'
     implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.20.1:4.4.9')
@@ -78,7 +125,12 @@ dependencies {
     // Optional client runtime used by runClient to validate emissive textures,
     // PBR materials, shaders and custom player/entity rendering. These are not
     // transitive requirements for users of SCP Additions.
-    runtimeOnly fg.deobf('maven.modrinth:HFlxNpln:wBmYGKE8') // MoreMcmeta 4.5.1
+    runtimeOnly fg.deobf(files(moreMcmetaCoreJar))
+    fileTree(moreMcmetaPluginDir).matching {
+        include '*.jar'
+    }.files.sort().each { pluginJar ->
+        runtimeOnly fg.deobf(files(pluginJar))
+    }
     runtimeOnly fg.deobf('maven.modrinth:oQ0dIGZg:rkJ3fswP') // MoreMcmeta Emissive 2.0.4
     runtimeOnly fg.deobf('maven.modrinth:oaG6aa1j:u7GegV7U') // Kleider's Custom Renderer 7.4.1
     runtimeOnly fg.deobf('maven.modrinth:sk9rgfiA:UTbfe5d1') // Embeddium 0.3.31

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ minecraft {
 }
 
 repositories {
+    flatDir {
+        name = 'MoreMcmetaDevRuntime'
+        dirs layout.buildDirectory.dir('moremcmeta-dev-runtime')
+        dirs layout.buildDirectory.dir('moremcmeta-dev-runtime/plugins')
+    }
+
     maven {
         name = 'GeckoLib'
         url = 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/'
@@ -86,7 +92,7 @@ dependencies {
 
 def moreMcmetaDevDir = layout.buildDirectory.dir('moremcmeta-dev-runtime').get().asFile
 def moreMcmetaBundleJar = configurations.moreMcmetaBundle.singleFile
-def moreMcmetaCoreJar = new File(moreMcmetaDevDir, 'moremcmeta-core.jar')
+def moreMcmetaCoreJar = new File(moreMcmetaDevDir, 'moremcmeta-core-dev.jar')
 def moreMcmetaPluginDir = new File(moreMcmetaDevDir, 'plugins')
 def moreMcmetaStamp = new File(moreMcmetaDevDir, '.source-sha1')
 def moreMcmetaSourceSha1 = java.security.MessageDigest.getInstance('SHA-1')
@@ -103,7 +109,9 @@ if (!moreMcmetaStamp.exists()
     project.copy {
         from zipTree(moreMcmetaBundleJar)
         include 'META-INF/jars/*.jar'
-        eachFile { details -> details.path = details.name }
+        eachFile { details ->
+            details.path = details.name.replaceFirst(/\.jar$/, '-dev.jar')
+        }
         includeEmptyDirs = false
         into moreMcmetaPluginDir
     }
@@ -125,11 +133,12 @@ dependencies {
     // Optional client runtime used by runClient to validate emissive textures,
     // PBR materials, shaders and custom player/entity rendering. These are not
     // transitive requirements for users of SCP Additions.
-    runtimeOnly fg.deobf(files(moreMcmetaCoreJar))
+    runtimeOnly fg.deobf('dev.moremcmeta:moremcmeta-core:dev')
     fileTree(moreMcmetaPluginDir).matching {
-        include '*.jar'
+        include '*-dev.jar'
     }.files.sort().each { pluginJar ->
-        runtimeOnly fg.deobf(files(pluginJar))
+        def artifactName = pluginJar.name.replaceFirst(/-dev\.jar$/, '')
+        runtimeOnly fg.deobf("dev.moremcmeta:${artifactName}:dev")
     }
     runtimeOnly fg.deobf('maven.modrinth:oQ0dIGZg:rkJ3fswP') // MoreMcmeta Emissive 2.0.4
     runtimeOnly fg.deobf('maven.modrinth:oaG6aa1j:u7GegV7U') // Kleider's Custom Renderer 7.4.1


### PR DESCRIPTION
Removes the nested JarJar plugins from the development copy of MoreMcmeta, extracts them, and passes each plugin independently through ForgeGradle deobfuscation. This fixes the runClient NoSuchMethodError caused by the properties parser remaining in production mappings. Also updates MoreMcmeta core to 4.5.2. All dependencies remain runtime-only and outside the SCP Additions JAR.