### PR TITLE
Add hunger replacement and misc gameplay tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@
 - Added `/disableAllRoamers`, `/enableAllRoamers`, `/despawnAllRoamers`, `/despawnRoamer <scp173|scp106>`, and `/roamerForceSpawn <scp173|scp106>`;
 - Added optional Debug Tools displays showing each roamer's state, next check, and latest result.
 
+## Survival
+
+- Added a default-enabled **Disable Hunger System** module that hides the vanilla hunger bar and converts food nutrition directly into health;
+- Replaced hunger-based natural healing with delayed regeneration: one health point every six seconds after 30 seconds without damage;
+- Saturation now reduces the regeneration delay to five seconds and restores the normal four-second interval, while Hunger prevents natural regeneration.
+
 ## Audio and presentation
 
 - Reintroduced the world-entry sound and added a General & Modules option to disable it;
@@ -63,6 +69,7 @@
 - Added an SL1 ceiling lamp that emits light while powered by redstone.
 - Added decorative Emergency Button and Fire Extinguisher facility props;
 - Added clear decorative-only tooltips to facility props that have no gameplay function;
+- Added dedicated inventory textures for enabled and disabled Tesla Gate Terminals, renamed the disabled variant, and made right-click switch between their visual states;
 - Moved Vent directly after Trashbin in the facility creative tab and removed the obsolete Alarm Lamp block and its resources.
 
 ## Accessibility

--- a/config/scpadditions/modules.json
+++ b/config/scpadditions/modules.json
@@ -15,6 +15,9 @@
     "stamina_enabled": true,
     "horror_movement_enabled": true
   },
+  "hunger": {
+    "disabled": true
+  },
   "blink": {
     "enabled": true
   },

--- a/docs/CONFIGURATION_CENTER.md
+++ b/docs/CONFIGURATION_CENTER.md
@@ -25,6 +25,7 @@ Malformed existing JSON is rejected instead of being silently replaced by fallba
 The center includes dedicated editors for:
 
 - gameplay modules and interface switches;
+- hunger replacement, food healing and delayed regeneration;
 - accessibility options, beginning with photosensitive-epilepsy controls;
 - SCP Inventory item categories and equipment effects;
 - hidden Status effects;

--- a/docs/migration/TEST_MATRIX.md
+++ b/docs/migration/TEST_MATRIX.md
@@ -67,7 +67,12 @@ Every migration phase must pass `clean build` and a client startup smoke test be
 - [ ] HUD scales correctly at common GUI scales
 - [ ] disabling inventory prevents replacement behavior cleanly
 - [ ] `hud.enabled=true` and `custom_health_enabled=true` render the custom health bar
-- [ ] custom health HUD cancels only vanilla player hearts, not armor, hunger, air or mount health
+- [ ] custom health HUD cancels only vanilla player hearts, not armor, air or mount health
+- [ ] `hunger.disabled=true` hides only the vanilla hunger bar, converts food nutrition to health and preserves sprint availability
+- [ ] custom natural regeneration first heals after 30 damage-free seconds and then every six seconds
+- [ ] Saturation changes the custom regeneration delay to five seconds and interval to four seconds
+- [ ] Hunger prevents custom natural regeneration until the effect ends
+- [ ] `hunger.disabled=false` restores vanilla hunger, food and natural regeneration without other changes
 - [ ] `custom_health_enabled=false` restores vanilla hearts and removes only the custom health row
 - [ ] `hud.enabled=false` restores vanilla hearts and hides both custom rows without disabling stamina gameplay
 - [ ] creative and spectator modes never render custom health or stamina rows

--- a/docs/migration/UI_INTERACTION_POLICY.md
+++ b/docs/migration/UI_INTERACTION_POLICY.md
@@ -10,6 +10,7 @@ The integrated systems are independently configurable in `config/scpadditions/mo
 - `vitals.custom_health_enabled` controls the custom health system and its HUD component.
 - `vitals.stamina_enabled` controls stamina behavior and its HUD component.
 - `vitals.horror_movement_enabled` controls the horror movement behavior.
+- `hunger.disabled` replaces vanilla hunger with food-based healing and delayed natural regeneration.
 
 Registry entries and stored capability data must remain available while a module is disabled. A toggle disables behavior and presentation; it must not unregister content or delete saved data.
 
@@ -25,6 +26,10 @@ The vanilla health hearts are suppressed only when both conditions are true:
 If either setting is false, vanilla hearts remain visible. Disabling only stamina must not affect vanilla health rendering.
 
 The stamina HUD is rendered only when both `hud.enabled` and `vitals.stamina_enabled` are true.
+
+The vanilla hunger bar is suppressed whenever `hunger.disabled` is true,
+independently of the custom HUD toggle. Setting it to false restores vanilla
+hunger, food and natural-regeneration behavior as one complete system.
 
 ## Font scope
 

--- a/src/main/java/com/bl4ues/scpinventory/config/InventoryModuleRuntimeState.java
+++ b/src/main/java/com/bl4ues/scpinventory/config/InventoryModuleRuntimeState.java
@@ -12,6 +12,7 @@ import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
 public final class InventoryModuleRuntimeState {
     private static volatile Boolean serverEnabled;
     private static volatile Boolean serverReduceScp012VisualEffects;
+    private static volatile Boolean serverHungerDisabled;
 
     private InventoryModuleRuntimeState() {
     }
@@ -28,14 +29,23 @@ public final class InventoryModuleRuntimeState {
                 .reduceScp012VisualEffects;
     }
 
+    public static boolean hungerDisabledForClient() {
+        Boolean synced = serverHungerDisabled;
+        return synced != null ? synced
+                : ScpAdditionsModulesConfig.get().hunger.disabled;
+    }
+
     public static void updateFromServer(boolean enabled,
-                                        boolean reduceScp012VisualEffects) {
+                                        boolean reduceScp012VisualEffects,
+                                        boolean hungerDisabled) {
         serverEnabled = enabled;
         serverReduceScp012VisualEffects = reduceScp012VisualEffects;
+        serverHungerDisabled = hungerDisabled;
     }
 
     public static void clearServerState() {
         serverEnabled = null;
         serverReduceScp012VisualEffects = null;
+        serverHungerDisabled = null;
     }
 }

--- a/src/main/java/com/bl4ues/scpinventory/network/InventoryActionPacket.java
+++ b/src/main/java/com/bl4ues/scpinventory/network/InventoryActionPacket.java
@@ -13,6 +13,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
 import net.mcreator.scpadditions.equipment.HazmatSuitAccess;
 import net.mcreator.scpadditions.equipment.HazmatSuitEvents;
+import net.mcreator.scpadditions.vitals.HungerSystemEvents;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -132,6 +133,7 @@ public class InventoryActionPacket {
                 0.9F + player.getRandom().nextFloat() * 0.2F
         );
 
+        HungerSystemEvents.healFromFood(player, usedStack);
         ItemStack result = usedStack.finishUsingItem(player.level(), player);
         stack.shrink(1);
         inventory.setInventoryItem(slot, stack.isEmpty() ? ItemStack.EMPTY : stack);

--- a/src/main/java/com/bl4ues/scpinventory/network/InventoryModuleStatePacket.java
+++ b/src/main/java/com/bl4ues/scpinventory/network/InventoryModuleStatePacket.java
@@ -7,22 +7,25 @@ import net.minecraftforge.network.NetworkEvent;
 import java.util.function.Supplier;
 
 public record InventoryModuleStatePacket(boolean enabled,
-                                         boolean reduceScp012VisualEffects) {
+                                         boolean reduceScp012VisualEffects,
+                                         boolean hungerDisabled) {
     public static void encode(InventoryModuleStatePacket message, FriendlyByteBuf buffer) {
         buffer.writeBoolean(message.enabled);
         buffer.writeBoolean(message.reduceScp012VisualEffects);
+        buffer.writeBoolean(message.hungerDisabled);
     }
 
     public static InventoryModuleStatePacket decode(FriendlyByteBuf buffer) {
         return new InventoryModuleStatePacket(buffer.readBoolean(),
-                buffer.readBoolean());
+                buffer.readBoolean(), buffer.readBoolean());
     }
 
     public static void handle(InventoryModuleStatePacket message,
                               Supplier<NetworkEvent.Context> supplier) {
         NetworkEvent.Context context = supplier.get();
         context.enqueueWork(() -> InventoryModuleRuntimeState.updateFromServer(
-                message.enabled, message.reduceScp012VisualEffects));
+                message.enabled, message.reduceScp012VisualEffects,
+                message.hungerDisabled));
         context.setPacketHandled(true);
     }
 }

--- a/src/main/java/com/bl4ues/scpinventory/network/MainUseActionPacket.java
+++ b/src/main/java/com/bl4ues/scpinventory/network/MainUseActionPacket.java
@@ -11,6 +11,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
 import net.mcreator.scpadditions.equipment.HazmatSuitAccess;
 import net.mcreator.scpadditions.equipment.HazmatSuitEvents;
+import net.mcreator.scpadditions.vitals.HungerSystemEvents;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -103,6 +104,7 @@ public class MainUseActionPacket {
                 0.9F + player.getRandom().nextFloat() * 0.2F
         );
 
+        HungerSystemEvents.healFromFood(player, usedStack);
         ItemStack result = usedStack.finishUsingItem(player.level(), player);
         stack.shrink(1);
         inventory.setInventoryItem(slot, stack.isEmpty() ? ItemStack.EMPTY : stack);

--- a/src/main/java/com/bl4ues/scpinventory/network/ModNetwork.java
+++ b/src/main/java/com/bl4ues/scpinventory/network/ModNetwork.java
@@ -12,7 +12,7 @@ import net.mcreator.scpadditions.config.ui.ConfigCenterNetwork;
 import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
 
 public final class ModNetwork {
-    private static final String PROTOCOL_VERSION = "7";
+    private static final String PROTOCOL_VERSION = "8";
     private static boolean registered;
 
     public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
@@ -74,7 +74,8 @@ public final class ModNetwork {
                 new InventoryModuleStatePacket(
                         ScpAdditionsModulesConfig.get().inventory.enabled,
                         ScpAdditionsModulesConfig.get().accessibility
-                                .reduceScp012VisualEffects));
+                                .reduceScp012VisualEffects,
+                        ScpAdditionsModulesConfig.get().hunger.disabled));
     }
 
     public static void syncModuleState(Iterable<ServerPlayer> players) {

--- a/src/main/java/net/mcreator/scpadditions/block/TeslaTerminalBlockBlock.java
+++ b/src/main/java/net/mcreator/scpadditions/block/TeslaTerminalBlockBlock.java
@@ -46,6 +46,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
 
 import net.mcreator.scpadditions.init.ScpAdditionsModGameRules;
+import net.mcreator.scpadditions.init.ScpAdditionsModBlocks;
 import net.mcreator.scpadditions.world.inventory.TeslaTerminalMenu;
 
 import java.util.List;
@@ -157,7 +158,16 @@ public class TeslaTerminalBlockBlock extends Block implements SimpleWaterloggedB
 
 	@Override
 	public InteractionResult use(BlockState blockstate, Level world, BlockPos pos, Player entity, InteractionHand hand, BlockHitResult hit) {
-		super.use(blockstate, world, pos, entity, hand, hit);
+		if (!entity.isShiftKeyDown()) {
+			if (!world.isClientSide) {
+				BlockState disabled = ScpAdditionsModBlocks.TESLA_TERMINAL_OFF.get()
+						.defaultBlockState()
+						.setValue(TeslaTerminalOffBlock.FACING, blockstate.getValue(FACING))
+						.setValue(TeslaTerminalOffBlock.WATERLOGGED, blockstate.getValue(WATERLOGGED));
+				world.setBlock(pos, disabled, Block.UPDATE_ALL);
+			}
+			return InteractionResult.sidedSuccess(world.isClientSide);
+		}
 		if (entity instanceof ServerPlayer player) {
 			boolean teslaOn = world.getLevelData().getGameRules().getBoolean(ScpAdditionsModGameRules.TESLAGATEON);
 			boolean manualOverride = world.getLevelData().getGameRules().getBoolean(ScpAdditionsModGameRules.TESLAGATEMANUALOVERRIDE);
@@ -180,6 +190,6 @@ public class TeslaTerminalBlockBlock extends Block implements SimpleWaterloggedB
 				data.writeBoolean(manualOverride);
 			});
 		}
-		return InteractionResult.SUCCESS;
+		return InteractionResult.sidedSuccess(world.isClientSide);
 	}
 }

--- a/src/main/java/net/mcreator/scpadditions/block/TeslaTerminalOffBlock.java
+++ b/src/main/java/net/mcreator/scpadditions/block/TeslaTerminalOffBlock.java
@@ -32,6 +32,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.network.chat.Component;
 import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
+import net.mcreator.scpadditions.init.ScpAdditionsModBlocks;
 
 import java.util.List;
 import java.util.Collections;
@@ -119,6 +120,13 @@ public class TeslaTerminalOffBlock extends Block implements SimpleWaterloggedBlo
 
 	@Override
 	public InteractionResult use(BlockState blockstate, Level world, BlockPos pos, Player entity, InteractionHand hand, BlockHitResult hit) {
-		return InteractionResult.SUCCESS;
+		if (!world.isClientSide) {
+			BlockState enabled = ScpAdditionsModBlocks.TESLA_TERMINAL_BLOCK.get()
+					.defaultBlockState()
+					.setValue(TeslaTerminalBlockBlock.FACING, blockstate.getValue(FACING))
+					.setValue(TeslaTerminalBlockBlock.WATERLOGGED, blockstate.getValue(WATERLOGGED));
+			world.setBlock(pos, enabled, Block.UPDATE_ALL);
+		}
+		return InteractionResult.sidedSuccess(world.isClientSide);
 	}
 }

--- a/src/main/java/net/mcreator/scpadditions/client/GameplayItemTooltipEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/client/GameplayItemTooltipEvents.java
@@ -48,9 +48,12 @@ public final class GameplayItemTooltipEvents {
             case "default_door", "yellow_closed", "black_closed" -> addPair(tooltip,
                     "tooltip.scp_additions.heavy_door_primary",
                     "tooltip.scp_additions.heavy_door_secondary");
-            case "tesla_terminal_block", "tesla_terminal_off" -> addPair(tooltip,
+            case "tesla_terminal_block" -> addPair(tooltip,
                     "tooltip.scp_additions.tesla_terminal_primary",
                     "tooltip.scp_additions.tesla_terminal_secondary");
+            case "tesla_terminal_off" -> tooltip.add(
+                    Component.translatable("tooltip.scp_additions.decorative_prop")
+                            .withStyle(ChatFormatting.GRAY));
             default -> {
             }
         }

--- a/src/main/java/net/mcreator/scpadditions/client/UnityConfigurationUiEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/client/UnityConfigurationUiEvents.java
@@ -82,6 +82,7 @@ public final class UnityConfigurationUiEvents {
             "Enables custom health behavior.",
             "Enables stamina drain and regeneration.",
             "Uses slower walking and committed sprinting.",
+            "Hides hunger, makes food restore health, and uses damage-delay regeneration.",
             "Enables automatic and manual blinking.",
             "Enables SCP-173 behavior.",
             "Allows the configurable natural spawn system.");

--- a/src/main/java/net/mcreator/scpadditions/client/WitherLoopSound.java
+++ b/src/main/java/net/mcreator/scpadditions/client/WitherLoopSound.java
@@ -13,7 +13,7 @@ import net.mcreator.scpadditions.init.Scp106Sounds;
 /** Positional Wither loop that follows one affected player and fades cleanly. */
 public final class WitherLoopSound extends AbstractTickableSoundInstance {
     private static final float MINIMUM_START_VOLUME = 0.01F;
-    private static final float TARGET_VOLUME = 0.85F;
+    private static final float TARGET_VOLUME = 1.70F;
     private static final int FADE_IN_TICKS = 20;
     private static final int FADE_OUT_TICKS = 30;
 

--- a/src/main/java/net/mcreator/scpadditions/config/ScpAdditionsModulesConfig.java
+++ b/src/main/java/net/mcreator/scpadditions/config/ScpAdditionsModulesConfig.java
@@ -77,6 +77,7 @@ public final class ScpAdditionsModulesConfig {
 		public Interactions interactions = new Interactions();
 		public Toggle hud = new Toggle();
 		public Vitals vitals = new Vitals();
+		public Hunger hunger = new Hunger();
 		public Toggle blink = new Toggle();
 		public Audio audio = new Audio();
 		public Accessibility accessibility = new Accessibility();
@@ -94,6 +95,7 @@ public final class ScpAdditionsModulesConfig {
 			if (interactions == null) interactions = new Interactions();
 			if (hud == null) hud = new Toggle();
 			if (vitals == null) vitals = new Vitals();
+			if (hunger == null) hunger = new Hunger();
 			if (blink == null) blink = new Toggle();
 			if (audio == null) audio = new Audio();
 			if (accessibility == null) accessibility = new Accessibility();
@@ -126,6 +128,10 @@ public final class ScpAdditionsModulesConfig {
 
 		@SerializedName("horror_movement_enabled")
 		public boolean horrorMovementEnabled = true;
+	}
+
+	public static final class Hunger {
+		public boolean disabled = true;
 	}
 
 	public static final class Audio {

--- a/src/main/java/net/mcreator/scpadditions/config/ScpAdditionsReloadCommand.java
+++ b/src/main/java/net/mcreator/scpadditions/config/ScpAdditionsReloadCommand.java
@@ -116,6 +116,7 @@ public final class ScpAdditionsReloadCommand {
         requireObjectIfPresent(root, "interactions", path, errors);
         requireObjectIfPresent(root, "hud", path, errors);
         requireObjectIfPresent(root, "vitals", path, errors);
+        requireObjectIfPresent(root, "hunger", path, errors);
         requireObjectIfPresent(root, "blink", path, errors);
         requireObjectIfPresent(root, "audio", path, errors);
         requireObjectIfPresent(root, "accessibility", path, errors);
@@ -123,6 +124,7 @@ public final class ScpAdditionsReloadCommand {
         requireObjectIfPresent(root, "scp_173", path, errors);
         validateBooleanMember(root, "inventory", "enabled", path, errors);
         validateBooleanMember(root, "inventory", "remember_ui_state", path, errors);
+        validateBooleanMember(root, "hunger", "disabled", path, errors);
         validateBooleanMember(root, "accessibility",
                 "reduce_scp_012_visual_effects", path, errors);
         rejectUnknownMember(root, "inventory", "disabled", path, errors,

--- a/src/main/java/net/mcreator/scpadditions/config/ui/ConfigCenterClient.java
+++ b/src/main/java/net/mcreator/scpadditions/config/ui/ConfigCenterClient.java
@@ -327,6 +327,7 @@ public final class ConfigCenterClient {
                 new ToggleSpec("vitals", "custom_health_enabled", "Custom Health", "Enables custom health behavior.", true),
                 new ToggleSpec("vitals", "stamina_enabled", "Stamina", "Enables stamina drain and regeneration.", true),
                 new ToggleSpec("vitals", "horror_movement_enabled", "Survival-Horror Movement", "Uses slower walking and committed sprinting.", true),
+                new ToggleSpec("hunger", "disabled", "Disable Hunger System", "Hides hunger, makes food restore health, and uses damage-delay regeneration.", true),
                 new ToggleSpec("blink", "enabled", "Blink System", "Enables automatic and manual blinking.", true),
                 new ToggleSpec("scp_173", "enabled", "SCP-173", "Enables SCP-173 behavior.", true),
                 new ToggleSpec("scp_173", "natural_spawn_enabled", "SCP-173 Natural Spawning", "Allows the configurable natural spawn system.", true)

--- a/src/main/java/net/mcreator/scpadditions/config/ui/ConfigCenterService.java
+++ b/src/main/java/net/mcreator/scpadditions/config/ui/ConfigCenterService.java
@@ -221,7 +221,7 @@ public final class ConfigCenterService {
 
     private static void validateModules(JsonObject root, List<String> errors) {
         for (String group : List.of("inventory", "interactions", "hud", "vitals",
-                "blink", "audio", "accessibility", "debug", "scp_173")) {
+                "hunger", "blink", "audio", "accessibility", "debug", "scp_173")) {
             if (root.has(group) && !root.get(group).isJsonObject()) errors.add(group + " must be an object");
         }
         checkBoolean(root, "inventory", "enabled", errors);
@@ -232,6 +232,7 @@ public final class ConfigCenterService {
         checkBoolean(root, "vitals", "custom_health_enabled", errors);
         checkBoolean(root, "vitals", "stamina_enabled", errors);
         checkBoolean(root, "vitals", "horror_movement_enabled", errors);
+        checkBoolean(root, "hunger", "disabled", errors);
         checkBoolean(root, "blink", "enabled", errors);
         checkBoolean(root, "audio", "enter_sound_enabled", errors);
         checkBoolean(root, "accessibility",
@@ -427,7 +428,7 @@ public final class ConfigCenterService {
     }
 
     private static JsonObject defaultModules() {
-        return JsonParser.parseString("{\"inventory\":{\"enabled\":true,\"remember_ui_state\":true},\"interactions\":{\"enabled\":true,\"disable_in_creative\":false},\"hud\":{\"enabled\":true},\"vitals\":{\"custom_health_enabled\":true,\"stamina_enabled\":true,\"horror_movement_enabled\":true},\"blink\":{\"enabled\":true},\"audio\":{\"enter_sound_enabled\":true},\"accessibility\":{\"reduce_scp_012_visual_effects\":false},\"scp_173\":{\"enabled\":true,\"natural_spawn_enabled\":true}}").getAsJsonObject();
+        return JsonParser.parseString("{\"inventory\":{\"enabled\":true,\"remember_ui_state\":true},\"interactions\":{\"enabled\":true,\"disable_in_creative\":false},\"hud\":{\"enabled\":true},\"vitals\":{\"custom_health_enabled\":true,\"stamina_enabled\":true,\"horror_movement_enabled\":true},\"hunger\":{\"disabled\":true},\"blink\":{\"enabled\":true},\"audio\":{\"enter_sound_enabled\":true},\"accessibility\":{\"reduce_scp_012_visual_effects\":false},\"scp_173\":{\"enabled\":true,\"natural_spawn_enabled\":true}}").getAsJsonObject();
     }
 
     private static JsonObject defaultInventory() {

--- a/src/main/java/net/mcreator/scpadditions/config/ui/Scp079ModulesScreenExtension.java
+++ b/src/main/java/net/mcreator/scpadditions/config/ui/Scp079ModulesScreenExtension.java
@@ -55,6 +55,8 @@ public final class Scp079ModulesScreenExtension {
                     "Enables stamina drain and regeneration.", true),
             new Row("vitals", "horror_movement_enabled", "Survival-Horror Movement",
                     "Uses slower walking and committed sprinting.", true),
+            new Row("hunger", "disabled", "Disable Hunger System",
+                    "Hides hunger, makes food restore health, and uses damage-delay regeneration.", true),
             new Row("blink", "enabled", "Blink System",
                     "Enables automatic and manual blinking.", true),
             new Row("audio", "enter_sound_enabled", "World Entry Sound",

--- a/src/main/java/net/mcreator/scpadditions/entity/Scp106Entity.java
+++ b/src/main/java/net/mcreator/scpadditions/entity/Scp106Entity.java
@@ -333,6 +333,7 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
         if (stateTicks > 0) stateTicks--;
         if (stateTicks > 0) return;
 
+        boolean emergedFromWall = getEncounterState() == EMERGING_WALL;
         relocationHiddenTicks = 0;
         setInvisible(false);
         setEncounterState(HUNTING);
@@ -342,6 +343,12 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
         blockedSightTicks = 0;
         stuckTicks = 0;
         phaseExitClearTicks = 0;
+        if (emergedFromWall) {
+            Player player = resolveHuntedPlayer();
+            if (player != null) {
+                faceDirection(horizontalDirectionTo(player));
+            }
+        }
     }
 
     private void tickHunt() {
@@ -893,7 +900,7 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
         Scp106CorrosionFieldManager.addRanged(serverLevel, puddle);
         serverLevel.playSound(null, puddle.x, puddle.y, puddle.z,
                 Scp106Sounds.RANGED_SPLASH.get(), SoundSource.HOSTILE,
-                0.85F, 0.96F + random.nextFloat() * 0.08F);
+                1.70F, 0.96F + random.nextFloat() * 0.08F);
 
         if (rangedHit) return;
         AABB hitbox = new AABB(puddle.x - 0.68D, puddle.y - 0.15D,
@@ -1268,7 +1275,7 @@ public class Scp106Entity extends PathfinderMob implements GeoEntity {
                         livingTarget.getY()
                                 + livingTarget.getBbHeight() * 0.5D,
                         livingTarget.getZ(), Scp106Sounds.HIT.get(),
-                        SoundSource.HOSTILE, 1.0F, 1.0F);
+                        SoundSource.HOSTILE, 2.0F, 1.0F);
             }
             livingTarget.addEffect(new MobEffectInstance(
                     MobEffects.WITHER,

--- a/src/main/java/net/mcreator/scpadditions/event/Scp106AudioEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/event/Scp106AudioEvents.java
@@ -124,7 +124,7 @@ public final class Scp106AudioEvents {
         if (!(scp106.level() instanceof ServerLevel level)) return;
         level.playSound(null, scp106.getX(), scp106.getY() + 0.05D,
                 scp106.getZ(), Scp106Sounds.STEP.get(),
-                SoundSource.HOSTILE, 0.9F,
+                SoundSource.HOSTILE, 1.8F,
                 0.96F + scp106.getRandom().nextFloat() * 0.08F);
     }
 

--- a/src/main/java/net/mcreator/scpadditions/vitals/HungerSystemEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/vitals/HungerSystemEvents.java
@@ -1,0 +1,160 @@
+package net.mcreator.scpadditions.vitals;
+
+import com.bl4ues.scpinventory.config.InventoryModuleRuntimeState;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.food.FoodData;
+import net.minecraft.world.food.FoodProperties;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameRules;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.living.LivingDamageEvent;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.mcreator.scpadditions.ScpAdditionsMod;
+import net.mcreator.scpadditions.config.ScpAdditionsModulesConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Replaces hunger with health-oriented food and delayed natural regeneration.
+ */
+@Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID,
+        bus = Mod.EventBusSubscriber.Bus.FORGE)
+public final class HungerSystemEvents {
+    private static final int NORMAL_REGEN_DELAY_TICKS = 30 * 20;
+    private static final int SATURATION_REGEN_DELAY_TICKS = 5 * 20;
+    private static final int NORMAL_REGEN_INTERVAL_TICKS = 6 * 20;
+    private static final int SATURATION_REGEN_INTERVAL_TICKS = 4 * 20;
+    private static final float REGEN_AMOUNT = 1.0F;
+    private static final Map<UUID, RegenerationState> REGENERATION =
+            new HashMap<>();
+
+    private HungerSystemEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        if (event.player.isCreative() || event.player.isSpectator()) {
+            if (!event.player.level().isClientSide) {
+                REGENERATION.remove(event.player.getUUID());
+            }
+            return;
+        }
+
+        boolean disabled = event.player.level().isClientSide
+                ? InventoryModuleRuntimeState.hungerDisabledForClient()
+                : ScpAdditionsModulesConfig.get().hunger.disabled;
+        if (!disabled) {
+            if (!event.player.level().isClientSide) {
+                REGENERATION.remove(event.player.getUUID());
+            }
+            return;
+        }
+
+        normalizeFoodData(event.player.getFoodData(),
+                event.player.getHealth() < event.player.getMaxHealth());
+        if (event.phase == TickEvent.Phase.END
+                && event.player instanceof ServerPlayer player) {
+            tickRegeneration(player);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onDamage(LivingDamageEvent event) {
+        if (event.getAmount() <= 0.0F
+                || !(event.getEntity() instanceof ServerPlayer player)
+                || !ScpAdditionsModulesConfig.get().hunger.disabled) {
+            return;
+        }
+        REGENERATION.computeIfAbsent(player.getUUID(),
+                ignored -> new RegenerationState()).reset();
+    }
+
+    @SubscribeEvent
+    public static void onFoodFinished(LivingEntityUseItemEvent.Finish event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            healFromFood(player, event.getItem());
+        }
+    }
+
+    public static void healFromFood(ServerPlayer player, ItemStack stack) {
+        if (player == null || stack == null || stack.isEmpty()
+                || player.isCreative() || player.isSpectator()
+                || !ScpAdditionsModulesConfig.get().hunger.disabled) {
+            return;
+        }
+
+        FoodProperties food = stack.getFoodProperties(player);
+        if (food == null || food.getNutrition() <= 0) return;
+
+        player.heal(food.getNutrition());
+        normalizeFoodData(player.getFoodData(),
+                player.getHealth() < player.getMaxHealth());
+    }
+
+    private static void normalizeFoodData(FoodData foodData,
+            boolean allowFoodUse) {
+        foodData.setFoodLevel(allowFoodUse ? 19 : 20);
+        foodData.setSaturation(0.0F);
+        foodData.setExhaustion(0.0F);
+        foodData.tickTimer = 0;
+    }
+
+    private static void tickRegeneration(ServerPlayer player) {
+        RegenerationState state = REGENERATION.computeIfAbsent(
+                player.getUUID(), ignored -> new RegenerationState());
+        state.ticksSinceDamage = Math.min(Integer.MAX_VALUE - 1,
+                state.ticksSinceDamage + 1);
+
+        if (!player.isAlive()
+                || player.getHealth() >= player.getMaxHealth()
+                || player.hasEffect(MobEffects.HUNGER)
+                || !player.level().getGameRules().getBoolean(
+                        GameRules.RULE_NATURAL_REGENERATION)) {
+            return;
+        }
+
+        boolean saturated = player.hasEffect(MobEffects.SATURATION);
+        int delay = saturated
+                ? SATURATION_REGEN_DELAY_TICKS
+                : NORMAL_REGEN_DELAY_TICKS;
+        if (state.ticksSinceDamage < delay) return;
+
+        int interval = saturated
+                ? SATURATION_REGEN_INTERVAL_TICKS
+                : NORMAL_REGEN_INTERVAL_TICKS;
+        if (state.lastHealTick < delay
+                || state.ticksSinceDamage - state.lastHealTick >= interval) {
+            player.heal(REGEN_AMOUNT);
+            state.lastHealTick = state.ticksSinceDamage;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onDeath(LivingDeathEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            REGENERATION.remove(player.getUUID());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        REGENERATION.remove(event.getEntity().getUUID());
+    }
+
+    private static final class RegenerationState {
+        private int ticksSinceDamage;
+        private int lastHealTick = -1;
+
+        private void reset() {
+            ticksSinceDamage = 0;
+            lastHealTick = -1;
+        }
+    }
+}

--- a/src/main/java/net/mcreator/scpadditions/vitals/client/ClientVitalsEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/vitals/client/ClientVitalsEvents.java
@@ -1,5 +1,6 @@
 package net.mcreator.scpadditions.vitals.client;
 
+import com.bl4ues.scpinventory.config.InventoryModuleRuntimeState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraftforge.api.distmarker.Dist;
@@ -27,7 +28,14 @@ public final class ClientVitalsEvents {
     @SubscribeEvent
     public static void beforeOverlay(RenderGuiOverlayEvent.Pre event) {
         LocalPlayer player = Minecraft.getInstance().player;
-        if (player != null && !player.isCreative() && !player.isSpectator()
+        if (player == null) return;
+        if (InventoryModuleRuntimeState.hungerDisabledForClient()
+                && event.getOverlay().id().equals(
+                        VanillaGuiOverlay.FOOD_LEVEL.id())) {
+            event.setCanceled(true);
+            return;
+        }
+        if (!player.isCreative() && !player.isSpectator()
                 && VitalsModule.healthHudEnabled()
                 && event.getOverlay().id().equals(VanillaGuiOverlay.PLAYER_HEALTH.id())) {
             event.setCanceled(true);

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -4,3 +4,4 @@ public-f net.minecraft.world.level.levelgen.feature.TreeFeature m_142674_(Lnet/m
 public com.mojang.blaze3d.audio.Channel f_83642_ # source
 public net.minecraft.client.sounds.SoundEngine f_120224_ # channelAccess
 public net.minecraft.client.sounds.SoundEngine f_120221_ # listener
+public net.minecraft.world.food.FoodData f_38699_ # tickTimer

--- a/src/main/resources/assets/scp_additions/lang/en_us.json
+++ b/src/main/resources/assets/scp_additions/lang/en_us.json
@@ -137,7 +137,7 @@
   "gamerule.scp079controlOn.description": "If SCP-079 has control over the facility",
   "advancements.tesla.descr": "Electrifying exit! You've earned a shocking send-off.",
   "subtitles.heartbeat": "Heartbeat",
-  "block.scp_additions.tesla_terminal_off": "Tesla Gate Terminal OFF",
+  "block.scp_additions.tesla_terminal_off": "Disabled Tesla Gate Terminal",
   "advancements.scp_330_achievement.title": "Sweet Tooth",
   "block.scp_additions.lv_6_left_reader_wrong": "Level 6 Keycard Reader (Left) Denied",
   "advancements.scp_079.title": "Digital Menace",

--- a/src/main/resources/assets/scp_additions/lang/en_us_3_0.json
+++ b/src/main/resources/assets/scp_additions/lang/en_us_3_0.json
@@ -56,7 +56,7 @@
   "tooltip.scp_additions.heavy_door_primary": "Redstone-operated heavy door with a 1.2 second opening cycle.",
   "tooltip.scp_additions.heavy_door_secondary": "Accepts power at the base or either upper relay height.",
   "tooltip.scp_additions.tesla_terminal_primary": "Controls the global enabled state and manual override of all loaded Tesla Gates.",
-  "tooltip.scp_additions.tesla_terminal_secondary": "Requires Security Credentials to access.",
+  "tooltip.scp_additions.tesla_terminal_secondary": "Right-click toggles its display; sneak + right-click opens controls with Security Credentials.",
   "tooltip.scp_additions.sl1_connected_floors": "Connects automatically with the other SL1 Floor Block.",
   "block.scp_additions.emergency_button": "Emergency Button",
   "block.scp_additions.fire_extinguisher": "Fire Extinguisher",

--- a/src/main/resources/assets/scp_additions/models/item/tesla_terminal_block.json
+++ b/src/main/resources/assets/scp_additions/models/item/tesla_terminal_block.json
@@ -1,1 +1,6 @@
-{"parent":"scp_additions:block/tesla_terminal_block"}
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "scp_additions:item/teslaon"
+  }
+}

--- a/src/main/resources/assets/scp_additions/models/item/tesla_terminal_off.json
+++ b/src/main/resources/assets/scp_additions/models/item/tesla_terminal_off.json
@@ -1,1 +1,6 @@
-{"parent":"scp_additions:block/tesla_terminal_off"}
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "scp_additions:item/teslaoff"
+  }
+}


### PR DESCRIPTION
## What changed

- doubles the new SCP-106 footsteps, confirmed hit, ranged splash, and Wither-loop volume
- realigns SCP-106 toward its target after completing a wall emergence
- adds enabled/disabled Tesla Terminal item textures, naming, tooltip, and in-world visual toggling while retaining controls on sneak-use
- adds the default-enabled hunger replacement: food heals by nutrition, damage-delayed regeneration, Saturation acceleration, and Hunger blocking
- synchronizes the hunger module to clients and documents the new behavior

## Validation

- `git diff --check`
- JSON parsing for configs, language files, and item models
- confirmed both uploaded terminal textures are valid 32×32 RGBA PNGs
- local Gradle execution is unavailable because the sandbox cannot reach the Gradle distribution; the repository Build workflow is the executable validation gate