### PR TITLE
Fix ceiling lamp and combat audio behavior

### DIFF
--- a/src/main/java/net/mcreator/scpadditions/client/CeilingLampAudioClient.java
+++ b/src/main/java/net/mcreator/scpadditions/client/CeilingLampAudioClient.java
@@ -16,6 +16,7 @@ public final class CeilingLampAudioClient {
     private static final int DISCOVERY_INTERVAL_TICKS = 10;
     private static final int HORIZONTAL_DISCOVERY_RADIUS = 16;
     private static final int VERTICAL_DISCOVERY_RADIUS = 8;
+    private static final double RETARGET_ADVANTAGE_SQ = 4.0D;
 
     private static CeilingLampLoopSound activeLoop;
     private static int discoveryTicks;
@@ -29,7 +30,10 @@ public final class CeilingLampAudioClient {
                 clientLevel.getBlockState(pos))) {
             return;
         }
-        startOrRetarget(clientLevel, pos);
+        if (activeLoop == null || activeLoop.isFinished()
+                || activeLoop.level() != clientLevel) {
+            startLoop(clientLevel, pos);
+        }
     }
 
     @SubscribeEvent
@@ -49,17 +53,38 @@ public final class CeilingLampAudioClient {
         discoveryTicks = 0;
 
         BlockPos nearest = findNearestPoweredLamp(minecraft.level,
-                minecraft.player.blockPosition());
+                minecraft.player.getX(), minecraft.player.getY(),
+                minecraft.player.getZ(), minecraft.player.blockPosition());
         if (nearest == null) stopLoop();
-        else startOrRetarget(minecraft.level, nearest);
+        else selectTarget(minecraft.level, nearest, minecraft.player.getX(),
+                minecraft.player.getY(), minecraft.player.getZ());
     }
 
-    private static void startOrRetarget(ClientLevel level, BlockPos pos) {
-        if (activeLoop != null && !activeLoop.isFinished()
-                && activeLoop.level() == level) {
-            activeLoop.retarget(pos);
+    private static void selectTarget(ClientLevel level, BlockPos candidate,
+            double listenerX, double listenerY, double listenerZ) {
+        if (activeLoop == null || activeLoop.isFinished()
+                || activeLoop.level() != level) {
+            startLoop(level, candidate);
             return;
         }
+
+        BlockPos current = activeLoop.target();
+        if (current.equals(candidate)) return;
+        if (!CeilingLampLoopSound.shouldPlayFor(level.getBlockState(current))) {
+            activeLoop.retarget(candidate);
+            return;
+        }
+
+        double currentDistance = distanceToCenterSqr(current, listenerX,
+                listenerY, listenerZ);
+        double candidateDistance = distanceToCenterSqr(candidate, listenerX,
+                listenerY, listenerZ);
+        if (candidateDistance + RETARGET_ADVANTAGE_SQ < currentDistance) {
+            activeLoop.retarget(candidate);
+        }
+    }
+
+    private static void startLoop(ClientLevel level, BlockPos pos) {
         stopLoop();
         activeLoop = new CeilingLampLoopSound(level, pos);
         Minecraft.getInstance().getSoundManager().play(activeLoop);
@@ -73,6 +98,7 @@ public final class CeilingLampAudioClient {
     }
 
     private static BlockPos findNearestPoweredLamp(ClientLevel level,
+            double listenerX, double listenerY, double listenerZ,
             BlockPos center) {
         BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
         BlockPos nearest = null;
@@ -88,7 +114,8 @@ public final class CeilingLampAudioClient {
                     if (!level.hasChunkAt(cursor)
                             || !CeilingLampLoopSound.shouldPlayFor(
                             level.getBlockState(cursor))) continue;
-                    double distance = cursor.distSqr(center);
+                    double distance = distanceToCenterSqr(cursor, listenerX,
+                            listenerY, listenerZ);
                     if (distance < nearestDistance) {
                         nearestDistance = distance;
                         nearest = cursor.immutable();
@@ -97,5 +124,13 @@ public final class CeilingLampAudioClient {
             }
         }
         return nearest;
+    }
+
+    private static double distanceToCenterSqr(BlockPos pos, double x,
+            double y, double z) {
+        double dx = pos.getX() + 0.5D - x;
+        double dy = pos.getY() + 0.5D - y;
+        double dz = pos.getZ() + 0.5D - z;
+        return dx * dx + dy * dy + dz * dz;
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/client/CeilingLampLoopSound.java
+++ b/src/main/java/net/mcreator/scpadditions/client/CeilingLampLoopSound.java
@@ -12,10 +12,15 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.mcreator.scpadditions.facility.UBlocksModule;
 import net.mcreator.scpadditions.init.ScpAdditionsModSounds;
 
-/** Positional electrical hum retargeted to the nearest powered ceiling lamp. */
+/** Positional electrical hum smoothly retargeted to a nearby powered ceiling lamp. */
 public final class CeilingLampLoopSound extends AbstractTickableSoundInstance {
+    private static final double POSITION_LERP = 0.18D;
+
     private final ClientLevel level;
-    private BlockPos pos;
+    private BlockPos target;
+    private double targetX;
+    private double targetY;
+    private double targetZ;
     private boolean finished;
 
     public CeilingLampLoopSound(ClientLevel level, BlockPos pos) {
@@ -28,24 +33,37 @@ public final class CeilingLampLoopSound extends AbstractTickableSoundInstance {
         this.pitch = 0.98F + RandomSource.create().nextFloat() * 0.04F;
         this.relative = false;
         this.attenuation = SoundInstance.Attenuation.LINEAR;
-        retarget(pos);
+        this.target = pos.immutable();
+        this.x = this.targetX = pos.getX() + 0.5D;
+        this.y = this.targetY = pos.getY() + 0.5D;
+        this.z = this.targetZ = pos.getZ() + 0.5D;
     }
 
     ClientLevel level() {
         return level;
     }
 
-    void retarget(BlockPos target) {
-        this.pos = target.immutable();
-        this.x = pos.getX() + 0.5D;
-        this.y = pos.getY() + 0.5D;
-        this.z = pos.getZ() + 0.5D;
+    BlockPos target() {
+        return target;
+    }
+
+    void retarget(BlockPos newTarget) {
+        this.target = newTarget.immutable();
+        this.targetX = target.getX() + 0.5D;
+        this.targetY = target.getY() + 0.5D;
+        this.targetZ = target.getZ() + 0.5D;
     }
 
     @Override
     public void tick() {
         Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.level != level || minecraft.player == null) finish();
+        if (minecraft.level != level || minecraft.player == null) {
+            finish();
+            return;
+        }
+        this.x += (targetX - this.x) * POSITION_LERP;
+        this.y += (targetY - this.y) * POSITION_LERP;
+        this.z += (targetZ - this.z) * POSITION_LERP;
     }
 
     static boolean shouldPlayFor(BlockState state) {

--- a/src/main/java/net/mcreator/scpadditions/client/PlayerDamageAudioClient.java
+++ b/src/main/java/net/mcreator/scpadditions/client/PlayerDamageAudioClient.java
@@ -22,8 +22,11 @@ import net.mcreator.scpadditions.init.ScpAdditionsModSounds;
 @Mod.EventBusSubscriber(modid = ScpAdditionsMod.MODID, value = Dist.CLIENT)
 public final class PlayerDamageAudioClient {
     private static final String PLAYER_HURT_PREFIX = "entity.player.hurt";
+    private static final String PLAYER_DEATH_PREFIX = "entity.player.death";
     private static final String PLAYER_ATTACK_PREFIX = "entity.player.attack.";
-    private static long suppressMobImpactUntilTick = Long.MIN_VALUE;
+    private static final double LOCAL_PLAYER_SOUND_RADIUS_SQ = 9.0D;
+    private static final long MOB_IMPACT_WINDOW_NANOS = 300_000_000L;
+    private static volatile long suppressMobImpactUntilNanos = Long.MIN_VALUE;
 
     private PlayerDamageAudioClient() {
     }
@@ -31,12 +34,15 @@ public final class PlayerDamageAudioClient {
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
         Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.level == null || event.getEntity() != minecraft.player) {
+        if (minecraft.player == null
+                || !event.getEntity().getUUID().equals(
+                minecraft.player.getUUID())) {
             return;
         }
         if (event.getTarget() instanceof LivingEntity
                 && !(event.getTarget() instanceof Player)) {
-            suppressMobImpactUntilTick = minecraft.level.getGameTime() + 4L;
+            suppressMobImpactUntilNanos = System.nanoTime()
+                    + MOB_IMPACT_WINDOW_NANOS;
         }
     }
 
@@ -47,35 +53,55 @@ public final class PlayerDamageAudioClient {
         ResourceLocation location = original.getLocation();
         if (location == null) return;
 
+        boolean minecraftSound = "minecraft".equals(location.getNamespace());
+        boolean localPlayerSound = isLocalPlayerSound(original);
+        String path = location.getPath();
+
         if (InventoryModuleRuntimeState.replacePlayerHurtSoundsForClient()
-                && "minecraft".equals(location.getNamespace())
-                && location.getPath().startsWith(PLAYER_HURT_PREFIX)) {
-            RandomSource random = RandomSource.create();
-            float pitch = Mth.clamp(original.getPitch()
-                    * (0.96F + random.nextFloat() * 0.08F), 0.5F, 2.0F);
-            event.setSound(new SimpleSoundInstance(
-                    ScpAdditionsModSounds.PLAYER_HURT.get().getLocation(),
-                    original.getSource(), original.getVolume(), pitch, random,
-                    original.isLooping(), original.getDelay(),
-                    original.getAttenuation(), original.getX(), original.getY(),
-                    original.getZ(), original.isRelative()));
-            return;
+                && minecraftSound && localPlayerSound) {
+            if (path.startsWith(PLAYER_HURT_PREFIX)) {
+                event.setSound(localHurtReplacement(original));
+                return;
+            }
+            if (path.startsWith(PLAYER_DEATH_PREFIX)) {
+                event.setSound(null);
+                return;
+            }
         }
 
         if (InventoryModuleRuntimeState.muteNonPlayerHitSoundsForClient()
-                && "minecraft".equals(location.getNamespace())
-                && location.getPath().startsWith(PLAYER_ATTACK_PREFIX)
+                && minecraftSound && localPlayerSound
+                && path.startsWith(PLAYER_ATTACK_PREFIX)
                 && isNonPlayerMobImpact()) {
             event.setSound(null);
         }
     }
 
+    private static SoundInstance localHurtReplacement(SoundInstance original) {
+        RandomSource random = RandomSource.create();
+        float pitch = Mth.clamp(original.getPitch()
+                * (0.96F + random.nextFloat() * 0.08F), 0.5F, 2.0F);
+        return new SimpleSoundInstance(
+                ScpAdditionsModSounds.PLAYER_HURT.get().getLocation(),
+                original.getSource(), original.getVolume(), pitch, random,
+                false, 0, SoundInstance.Attenuation.NONE,
+                0.0D, 0.0D, 0.0D, true);
+    }
+
+    private static boolean isLocalPlayerSound(SoundInstance sound) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null) return false;
+        if (sound.isRelative()) return true;
+        double dx = sound.getX() - minecraft.player.getX();
+        double dy = sound.getY() - minecraft.player.getY();
+        double dz = sound.getZ() - minecraft.player.getZ();
+        return dx * dx + dy * dy + dz * dz
+                <= LOCAL_PLAYER_SOUND_RADIUS_SQ;
+    }
+
     private static boolean isNonPlayerMobImpact() {
         Minecraft minecraft = Minecraft.getInstance();
-        if (minecraft.level == null) return false;
-        if (minecraft.level.getGameTime() <= suppressMobImpactUntilTick) {
-            return true;
-        }
+        if (System.nanoTime() <= suppressMobImpactUntilNanos) return true;
         return minecraft.hitResult instanceof EntityHitResult hit
                 && hit.getEntity() instanceof LivingEntity
                 && !(hit.getEntity() instanceof Player);

--- a/src/main/java/net/mcreator/scpadditions/event/Scp106AudioEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/event/Scp106AudioEvents.java
@@ -124,7 +124,7 @@ public final class Scp106AudioEvents {
         if (!(scp106.level() instanceof ServerLevel level)) return;
         level.playSound(null, scp106.getX(), scp106.getY() + 0.05D,
                 scp106.getZ(), Scp106Sounds.STEP.get(),
-                SoundSource.HOSTILE, 0.9F,
+                SoundSource.HOSTILE, 0.63F,
                 0.96F + scp106.getRandom().nextFloat() * 0.08F);
     }
 


### PR DESCRIPTION
Fixes the active ceiling-lamp hum jumping between randomly ticked lamps, smooths positional retargeting, restores local custom player hurt sounds, suppresses the vanilla local death cue when replacement audio is enabled, makes non-player impact muting reliably recognize the local attacker, and lowers SCP-106 footsteps by 30%.