### PR TITLE
Fix mob hit sound suppression and lower 106 footsteps

### DIFF
--- a/src/main/java/net/mcreator/scpadditions/client/PlayerDamageAudioClient.java
+++ b/src/main/java/net/mcreator/scpadditions/client/PlayerDamageAudioClient.java
@@ -11,6 +11,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.AttackEntityEvent;
@@ -39,6 +40,28 @@ public final class PlayerDamageAudioClient {
     private PlayerDamageAudioClient() {
     }
 
+    /**
+     * Mark the local mob attack before Minecraft creates its attack sound.
+     * AttackEntityEvent can arrive too late or only on the logical server, so
+     * the client input event is the authoritative timing source here.
+     */
+    @SubscribeEvent
+    public static void onInteractionKeyMapping(
+            InputEvent.InteractionKeyMappingTriggered event) {
+        if (!event.isAttack()) return;
+
+        Minecraft minecraft = Minecraft.getInstance();
+        if (!(minecraft.hitResult instanceof EntityHitResult hit)
+                || !(hit.getEntity() instanceof LivingEntity)
+                || hit.getEntity() instanceof Player) {
+            return;
+        }
+
+        suppressMobImpactUntilNanos = System.nanoTime()
+                + MOB_IMPACT_WINDOW_NANOS;
+    }
+
+    /** Server/integrated-server fallback for attacks not exposed by input. */
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
         Minecraft minecraft = Minecraft.getInstance();
@@ -118,8 +141,14 @@ public final class PlayerDamageAudioClient {
             }
         }
 
+        /*
+         * Attack sounds are commonly positioned at the struck entity rather
+         * than at the attacker, so the local-player distance test is invalid
+         * here. The short pre-attack window already proves this came from the
+         * local player hitting a non-player living entity.
+         */
         if (InventoryModuleRuntimeState.muteNonPlayerHitSoundsForClient()
-                && minecraftSound && localPlayerSound
+                && minecraftSound
                 && path.startsWith(PLAYER_ATTACK_PREFIX)
                 && isNonPlayerMobImpact()) {
             event.setSound(null);
@@ -155,10 +184,6 @@ public final class PlayerDamageAudioClient {
     }
 
     private static boolean isNonPlayerMobImpact() {
-        Minecraft minecraft = Minecraft.getInstance();
-        if (System.nanoTime() <= suppressMobImpactUntilNanos) return true;
-        return minecraft.hitResult instanceof EntityHitResult hit
-                && hit.getEntity() instanceof LivingEntity
-                && !(hit.getEntity() instanceof Player);
+        return System.nanoTime() <= suppressMobImpactUntilNanos;
     }
 }

--- a/src/main/java/net/mcreator/scpadditions/event/Scp106AudioEvents.java
+++ b/src/main/java/net/mcreator/scpadditions/event/Scp106AudioEvents.java
@@ -30,6 +30,8 @@ public final class Scp106AudioEvents {
     private static final double WALK_SECONDS_PER_TICK = 1.38D / 20.0D;
     private static final double FIRST_FOOTSTEP_SECONDS = 0.72D;
     private static final double FOOTSTEP_INTERVAL_SECONDS = 0.90D;
+    // Additional 30% reduction from the previous 0.63 volume.
+    private static final float FOOTSTEP_VOLUME = 0.441F;
     private static final Map<UUID, Tracked> TRACKED = new HashMap<>();
 
     private Scp106AudioEvents() {
@@ -124,7 +126,7 @@ public final class Scp106AudioEvents {
         if (!(scp106.level() instanceof ServerLevel level)) return;
         level.playSound(null, scp106.getX(), scp106.getY() + 0.05D,
                 scp106.getZ(), Scp106Sounds.STEP.get(),
-                SoundSource.HOSTILE, 0.63F,
+                SoundSource.HOSTILE, FOOTSTEP_VOLUME,
                 0.96F + scp106.getRandom().nextFloat() * 0.08F);
     }
 


### PR DESCRIPTION
Marks local mob attacks from the client interaction event before vanilla creates the attack sound, removes the invalid attacker-distance requirement for that filtered sound, and keeps the server attack event as a fallback. Also lowers SCP-106 footstep playback by an additional 30%, from 0.63 to 0.441.