### PR TITLE
Fix elevator collision, prompts, rendering, and SCP-330 scale

### DIFF
--- a/.github/workflows/apply-elevator-fix-v3.yml
+++ b/.github/workflows/apply-elevator-fix-v3.yml
@@ -1,0 +1,279 @@
+name: Apply elevator repair v3
+
+on:
+  push:
+    branches:
+      - fix/elevator-collision-prompts-v3
+    paths:
+      - tools/hotfix/APPLY_ELEVATOR_FIX_V3
+
+permissions:
+  contents: write
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/elevator-collision-prompts-v3
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Apply corrections
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          def replace_once(path, old, new, label):
+              text = path.read_text(encoding='utf-8')
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f'{label}: expected 1 match, found {count}')
+              path.write_text(text.replace(old, new, 1), encoding='utf-8')
+
+          # SCP-330: enlarge another 25 percent while preserving the lowest Y,
+          # then make placement face the player rather than away from them.
+          geo_path = Path('src/main/resources/assets/scp_additions/geo/block/scp330.geo.json')
+          geo = json.loads(geo_path.read_text(encoding='utf-8'))
+          scale = 1.25
+          for geometry in geo.get('minecraft:geometry', []):
+              description = geometry.get('description', {})
+              width = float(description.get('visible_bounds_width', 0.0))
+              if not 2.75 <= width <= 2.85:
+                  raise SystemExit(f'Unexpected SCP-330 width before scaling: {width}')
+              cubes = [cube for bone in geometry.get('bones', [])
+                       for cube in bone.get('cubes', [])
+                       if isinstance(cube.get('origin'), list)]
+              base_y = min(float(cube['origin'][1]) for cube in cubes)
+
+              def scale_position(vector):
+                  if not isinstance(vector, list) or len(vector) < 3:
+                      return
+                  vector[0] = round(float(vector[0]) * scale, 6)
+                  vector[1] = round(base_y + (float(vector[1]) - base_y) * scale, 6)
+                  vector[2] = round(float(vector[2]) * scale, 6)
+
+              def scale_size(vector):
+                  if not isinstance(vector, list) or len(vector) < 3:
+                      return
+                  for index in range(3):
+                      vector[index] = round(float(vector[index]) * scale, 6)
+
+              description['visible_bounds_width'] = round(width * scale, 6)
+              if 'visible_bounds_height' in description:
+                  description['visible_bounds_height'] = round(
+                      float(description['visible_bounds_height']) * scale, 6)
+              scale_position(description.get('visible_bounds_offset'))
+              for bone in geometry.get('bones', []):
+                  scale_position(bone.get('pivot'))
+                  for cube in bone.get('cubes', []):
+                      scale_position(cube.get('origin'))
+                      scale_size(cube.get('size'))
+                      scale_position(cube.get('pivot'))
+                  for locator in bone.get('locators', {}).values():
+                      scale_position(locator)
+          geo_path.write_text(json.dumps(geo, separators=(',', ':')) + '\n',
+                              encoding='utf-8')
+
+          scp330_path = Path('src/main/java/net/mcreator/scpadditions/block/Scp330Block.java')
+          scp330 = scp330_path.read_text(encoding='utf-8')
+          scp330, count = re.subn(
+              r'private static final VoxelShape SHAPE = box\(\s*'
+              r'5\.1875D, 0\.0D, 5\.1875D,\s*'
+              r'10\.8125D, 2\.1875D, 10\.8125D\);',
+              '''private static final VoxelShape SHAPE = box(
+              4.484375D, 0.0D, 4.484375D,
+              11.515625D, 2.734375D, 11.515625D);''',
+              scp330, count=1)
+          if count != 1:
+              raise SystemExit(f'SCP-330 collision replacement: {count}')
+          old_facing = '''        return defaultBlockState().setValue(FACING,
+                context.getHorizontalDirection());'''
+          new_facing = '''        return defaultBlockState().setValue(FACING,
+                context.getHorizontalDirection().getOpposite());'''
+          if scp330.count(old_facing) != 1:
+              raise SystemExit('SCP-330 placement facing block not found')
+          scp330_path.write_text(scp330.replace(old_facing, new_facing, 1),
+                                 encoding='utf-8')
+
+          # Station geometry: add the missing perimeter railings and mirror the
+          # station button anchor horizontally to the visible right-side panel.
+          geometry_path = Path('src/main/java/net/mcreator/scpadditions/facility/elevator/CoreRoomElevatorGeometry.java')
+          geometry = geometry_path.read_text(encoding='utf-8')
+          geometry = geometry.replace(
+              'private static final double STATION_BUTTON_X = 14.64492D / 16.0D;',
+              'private static final double STATION_BUTTON_X = -14.64492D / 16.0D;', 1)
+          rail_marker = '''            modelBox(-12, 0, -18.5, -10, 17, -14.25)
+    );'''
+          rail_replacement = '''            modelBox(-12, 0, -18.5, -10, 17, -14.25),
+            // Low glass/metal railings surrounding the carriage opening.
+            modelBox(-17, 0, 16.25, 17, 13.5, 17),
+            modelBox(-17, 0, -16.75, -16.25, 13.5, 17),
+            modelBox(16.25, 0, -16.75, 17, 13.5, 17),
+            modelBox(-17, 0, -16.75, -12, 13.5, -16.25),
+            modelBox(12, 0, -16.75, 17, 13.5, -16.25)
+    );'''
+          if geometry.count(rail_marker) != 1:
+              raise SystemExit('Station railing insertion point not found')
+          geometry_path.write_text(geometry.replace(rail_marker,
+                                                     rail_replacement, 1),
+                                   encoding='utf-8')
+
+          # Beams are generated shaft connectors and must remain unbreakable.
+          module_path = Path('src/main/java/net/mcreator/scpadditions/facility/elevator/CoreRoomElevatorModule.java')
+          module = module_path.read_text(encoding='utf-8')
+          beam_start = module.index('    public static final class BeamBlock')
+          beam_end = module.index('    public static final class CoreRoomFloorBlock', beam_start)
+          beam_section = module[beam_start:beam_end]
+          if beam_section.count('.strength(5.0F, 15.0F)') != 1:
+              raise SystemExit('Beam master strength not found exactly once')
+          beam_section = beam_section.replace('.strength(5.0F, 15.0F)',
+                                              '.strength(-1.0F, 3600000.0F)', 1)
+          module = module[:beam_start] + beam_section + module[beam_end:]
+          part_start = module.index('    private static final class BeamStructurePartBlock')
+          part_end = module.index('    public static final class StructurePartBlockEntity', part_start)
+          part_section = module[part_start:part_end]
+          if part_section.count('.strength(5.0F, 15.0F)') != 1:
+              raise SystemExit('Beam part strength not found exactly once')
+          part_section = part_section.replace('.strength(5.0F, 15.0F)',
+                                              '.strength(-1.0F, 3600000.0F)', 1)
+          module_path.write_text(module[:part_start] + part_section + module[part_end:],
+                                 encoding='utf-8')
+
+          # Both windowed models require a translucent render type.
+          client_path = Path('src/main/java/net/mcreator/scpadditions/facility/elevator/CoreRoomElevatorClient.java')
+          client = client_path.read_text(encoding='utf-8')
+          carriage_start = client.index('    public static final class CarriageRenderer')
+          carriage = client[carriage_start:]
+          if carriage.count('return RenderType.entityCutoutNoCull(texture);') != 1:
+              raise SystemExit('Carriage cutout render call not found')
+          carriage = carriage.replace('return RenderType.entityCutoutNoCull(texture);',
+                                      'return RenderType.entityTranslucentCull(texture);', 1)
+          client_path.write_text(client[:carriage_start] + carriage,
+                                 encoding='utf-8')
+
+          # Run moving-cabin shell/floor collision on the client as well as the
+          # server. Without client-side correction, local prediction falls through
+          # before the authoritative server can recover the player.
+          carriage_path = Path('src/main/java/net/mcreator/scpadditions/facility/elevator/CoreRoomElevatorCarriageEntity.java')
+          carriage = carriage_path.read_text(encoding='utf-8')
+          old_client_return = '        if (level().isClientSide) return;'
+          new_client_return = '''        if (level().isClientSide) {
+            previousServerY = getY();
+            resolveNearbyEntities(0.0D);
+            return;
+        }'''
+          if carriage.count(old_client_return) != 1:
+              raise SystemExit('Carriage client tick return not found')
+          carriage = carriage.replace(old_client_return, new_client_return, 1)
+          if carriage.count('cabinOuterBox().inflate(0.45D, 0.45D, 0.45D)') != 1:
+              raise SystemExit('Carriage collision search inflation not found')
+          carriage = carriage.replace(
+              'cabinOuterBox().inflate(0.45D, 0.45D, 0.45D)',
+              'cabinOuterBox().inflate(0.45D, 1.50D, 0.45D)', 1)
+          carriage_path.write_text(carriage, encoding='utf-8')
+
+          # Resolve station prompts from any nearby multiblock cell, not only the
+          # distant master cell. The packet still targets the actual master block.
+          prompt_path = Path('src/main/java/com/bl4ues/scpinventory/client/ContextPromptClient.java')
+          prompt = prompt_path.read_text(encoding='utf-8')
+          prompt = prompt.replace(
+              'private static final double PRECISE_AIM_RADIUS_SQR = 0.52D * 0.52D;',
+              'private static final double PRECISE_AIM_RADIUS_SQR = 0.60D * 0.60D;', 1)
+          start_marker = '            BlockPos pos = mutable.immutable();'
+          start = prompt.index(start_marker)
+          end_marker = '            }\n        }\n        return best;'
+          end = prompt.index(end_marker, start) + len('            }\n')
+          replacement = '''            BlockPos scannedPos = mutable.immutable();
+            BlockState scannedState = player.level().getBlockState(scannedPos);
+            BlockPos rulePos = scannedPos;
+            BlockState ruleState = scannedState;
+            if (player.level().getBlockEntity(scannedPos)
+                    instanceof CoreRoomElevatorModule.StructurePartBlockEntity part) {
+                BlockPos master = part.masterPos();
+                BlockState masterState = player.level().getBlockState(master);
+                if (masterState.getBlock()
+                        instanceof CoreRoomElevatorModule.StationBlock) {
+                    rulePos = master;
+                    ruleState = masterState;
+                }
+            }
+            List<ContextInteractionRegistry.Rule> rules =
+                    ContextInteractionRegistry.getBlockRules(ruleState.getBlock());
+            if (rules.isEmpty()) continue;
+            boolean directHit = blockHit != null
+                    && hitBelongsTo(blockHit.getBlockPos(), rulePos, player);
+            for (ContextInteractionRegistry.Rule rule : rules) {
+                if (!rule.isAvailable(player.level(), rulePos, ruleState)) continue;
+                Vec3 anchor = rule.resolveBlockAnchor(rulePos, ruleState);
+                double score = scorePoint(anchor, eye, look, rule.range(),
+                        directHit, rule.priority(),
+                        rule.requiresPreciseAim());
+                if (isCurrentBlockTarget(rulePos, rule.interactionKey())) {
+                    score -= TARGET_STICKINESS_BONUS;
+                }
+                if (score < bestScore && hasBlockLineOfSight(player, eye,
+                        anchor, rulePos, directHit)) {
+                    bestScore = score;
+                    String name = rule.showName()
+                            ? rule.blockName(ruleState) : "";
+                    boolean showName = rule.showName() && !name.isEmpty();
+                    boolean showAction = rule.showAction() && showName;
+                    ResourceLocation icon = ContextPromptIcons.resolve(
+                            rule.icon(), rule.id());
+                    best = new ContextTarget(rulePos, 0, false, anchor,
+                            rule.interactionKey(), rule.action(), name,
+                            showAction, showName, rule.allowE(),
+                            rule.allowRightClick(), icon,
+                            (float) rule.promptScale(), score);
+                }
+            }
+'''
+          prompt_path.write_text(prompt[:start] + replacement + prompt[end:],
+                                 encoding='utf-8')
+
+          # Requested creative-tab order: faucet, wet-floor sign, then trashbin.
+          facility_path = Path('src/main/java/net/mcreator/scpadditions/facility/FacilityModule.java')
+          facility = facility_path.read_text(encoding='utf-8')
+          old_order = '''        addFacilityCreativeItem(props, "wet_floor");
+        addFacilityCreativeItem(props, "water_faucet");
+        addFacilityCreativeItem(props, "scp_914_usage_notice");
+        addFacilityCreativeItem(props, "tv");
+        addFacilityCreativeItem(props, "trashbin");'''
+          new_order = '''        addFacilityCreativeItem(props, "water_faucet");
+        addFacilityCreativeItem(props, "wet_floor");
+        addFacilityCreativeItem(props, "trashbin");
+        addFacilityCreativeItem(props, "scp_914_usage_notice");
+        addFacilityCreativeItem(props, "tv");'''
+          if facility.count(old_order) != 1:
+              raise SystemExit('Creative prop order block not found')
+          facility_path.write_text(facility.replace(old_order, new_order, 1),
+                                   encoding='utf-8')
+          PY
+
+      - name: Remove temporary trigger files
+        run: |
+          rm -f tools/hotfix/APPLY_ELEVATOR_FIX_V3
+          rm -f .github/workflows/apply-elevator-fix-v3.yml
+
+      - name: Build
+        run: ./gradlew clean build --no-daemon --stacktrace
+
+      - name: Commit validated corrections
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Fix elevator collision, prompts, rendering, and SCP-330 scale"
+          git push origin HEAD:fix/elevator-collision-prompts-v3

--- a/tools/hotfix/APPLY_ELEVATOR_FIX_V3
+++ b/tools/hotfix/APPLY_ELEVATOR_FIX_V3
@@ -1,0 +1,1 @@
+Apply the prepared elevator, SCP-330, and creative-tab corrections.


### PR DESCRIPTION
Applies the requested second-pass fixes: restores unbreakable beams, restores translucent carriage rendering, adds station railing collision while preserving open/closed door collision, resolves station prompts through multiblock parts, mirrors the station button target to the visible side, runs cabin collision client-side, enlarges and reorients SCP-330, and reorders the creative props. The temporary workflow removes itself after a successful clean Gradle build.