### PR TITLE
Clean up context and item configuration editors

### DIFF
--- a/src/main/java/com/bl4ues/scpinventory/client/ContextConfigClientHandler.java
+++ b/src/main/java/com/bl4ues/scpinventory/client/ContextConfigClientHandler.java
@@ -1,6 +1,6 @@
 package com.bl4ues.scpinventory.client;
 
-import com.bl4ues.scpinventory.client.gui.ContextConfigScreen;
+import com.bl4ues.scpinventory.client.gui.ContextAnchorEditorScreen;
 import com.bl4ues.scpinventory.context.ContextInteractionRegistry;
 import com.bl4ues.scpinventory.network.ContextConfigOpenPacket;
 import net.minecraft.client.Minecraft;
@@ -14,7 +14,7 @@ public final class ContextConfigClientHandler {
 
     public static void open(ContextConfigOpenPacket packet) {
         Minecraft mc = Minecraft.getInstance();
-        mc.setScreen(new ContextConfigScreen(packet));
+        mc.setScreen(new ContextAnchorEditorScreen(packet));
     }
 
     public static void reloadContextConfig() {

--- a/src/main/java/com/bl4ues/scpinventory/client/ItemConfigClientHandler.java
+++ b/src/main/java/com/bl4ues/scpinventory/client/ItemConfigClientHandler.java
@@ -1,6 +1,6 @@
 package com.bl4ues.scpinventory.client;
 
-import com.bl4ues.scpinventory.client.gui.ItemConfigScreen;
+import com.bl4ues.scpinventory.client.gui.ItemRuleEditorScreen;
 import com.bl4ues.scpinventory.config.ScpInventoryConfig;
 import com.bl4ues.scpinventory.network.ItemConfigOpenPacket;
 import net.minecraft.client.Minecraft;
@@ -13,7 +13,7 @@ public final class ItemConfigClientHandler {
     }
 
     public static void open(ItemConfigOpenPacket packet) {
-        Minecraft.getInstance().setScreen(new ItemConfigScreen(packet));
+        Minecraft.getInstance().setScreen(new ItemRuleEditorScreen(packet));
     }
 
     public static void reloadItemConfig() {

--- a/src/main/java/com/bl4ues/scpinventory/client/gui/ContextAnchorEditorScreen.java
+++ b/src/main/java/com/bl4ues/scpinventory/client/gui/ContextAnchorEditorScreen.java
@@ -1,0 +1,628 @@
+package com.bl4ues.scpinventory.client.gui;
+
+import com.bl4ues.scpinventory.client.ScpFonts;
+import com.bl4ues.scpinventory.network.ContextConfigDeletePacket;
+import com.bl4ues.scpinventory.network.ContextConfigOpenPacket;
+import com.bl4ues.scpinventory.network.ContextConfigSavePacket;
+import com.bl4ues.scpinventory.network.ModNetwork;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+import org.lwjgl.glfw.GLFW;
+
+public final class ContextAnchorEditorScreen extends Screen {
+    private static final int PANEL_W = 330;
+    private static final int PANEL_H = 400;
+    private static final int MARGIN = 10;
+
+    private static final int NAVY = 0xF000071F;
+    private static final int NAVY_LIGHT = 0xE6141E42;
+    private static final int FIELD = 0xFF080D1C;
+    private static final int CONTROL = 0xFF111A31;
+    private static final int CONTROL_HOVER = 0xFF192744;
+    private static final int BORDER = 0xFF46536C;
+    private static final int BORDER_HOVER = 0xFF73809A;
+    private static final int ACCENT = 0xFFC59A2A;
+    private static final int ACCENT_TEXT = 0xFFE5D49A;
+    private static final int WHITE = 0xFFF7F8FC;
+    private static final int MUTED = 0xFFA9AFBA;
+    private static final int SECTION = 0xFFD3D9E4;
+    private static final int WARNING = 0xFFFFB35C;
+    private static final int DANGER = 0xFFD46060;
+
+    private final BlockPos pos;
+    private final String blockId;
+    private final boolean existing;
+    private final String startAction;
+    private final String startName;
+    private final String startRange;
+    private final boolean likelyRightClick;
+
+    private EditBox actionBox;
+    private EditBox nameBox;
+    private EditBox rangeBox;
+    private ButtonControl forgetButton;
+
+    private double anchorX;
+    private double anchorY;
+    private double anchorZ;
+    private boolean showName;
+    private boolean allowE;
+    private boolean allowRightClick;
+    private boolean allowOffscreen;
+    private String useItem;
+    private String clickFace;
+    private String rotateWith;
+    private boolean confirmForget;
+
+    public ContextAnchorEditorScreen(ContextConfigOpenPacket packet) {
+        super(ScpFonts.roboto("Context Interaction Editor"));
+        this.pos = packet.pos();
+        this.blockId = packet.blockId();
+        this.existing = packet.existing();
+        this.startAction = packet.action();
+        this.startName = packet.name();
+        this.startRange = Double.toString(packet.range());
+        this.showName = packet.showName();
+        this.allowE = packet.allowE();
+        this.allowRightClick = packet.allowRightClick();
+        this.allowOffscreen = packet.allowOffscreen();
+        this.likelyRightClick = packet.likelyRightClick();
+        this.useItem = "card".equalsIgnoreCase(packet.useItem()) ? "card" : "hand";
+        this.clickFace = packet.clickFace();
+        this.rotateWith = packet.rotateWith();
+        this.anchorX = packet.anchorX();
+        this.anchorY = packet.anchorY();
+        this.anchorZ = packet.anchorZ();
+    }
+
+    @Override
+    protected void init() {
+        int left = panelLeft();
+        int top = panelTop();
+        int x = left + 16;
+        int width = PANEL_W - 32;
+
+        actionBox = configureField(new EditBox(font, x, top + 92,
+                width, 20, ScpFonts.roboto("Action")));
+        actionBox.setValue(startAction == null || startAction.isBlank()
+                ? "Use" : startAction);
+        addRenderableWidget(actionBox);
+
+        nameBox = configureField(new EditBox(font, x, top + 127,
+                width - 92, 20, ScpFonts.roboto("Display name")));
+        nameBox.setValue(startName == null || startName.isBlank()
+                ? fallbackName() : startName);
+        addRenderableWidget(nameBox);
+        addRenderableWidget(new ButtonControl(x + width - 84, top + 127,
+                84, 20, nameDisplayText(), ButtonStyle.NEUTRAL, () -> {
+            showName = !showName;
+            refreshButtonMessages();
+        }));
+
+        rangeBox = configureField(new EditBox(font, x, top + 162,
+                64, 20, ScpFonts.roboto("Range")));
+        rangeBox.setValue(startRange == null ? "2.25" : startRange);
+        addRenderableWidget(rangeBox);
+        addRenderableWidget(new ButtonControl(x + 72, top + 162,
+                98, 20, inputText(), ButtonStyle.NEUTRAL, () -> {
+            cycleInput();
+            refreshButtonMessages();
+        }));
+        addRenderableWidget(new ButtonControl(x + 178, top + 162,
+                width - 178, 20, itemText(), ButtonStyle.NEUTRAL, () -> {
+            useItem = "card".equals(useItem) ? "hand" : "card";
+            refreshButtonMessages();
+        }));
+
+        addRenderableWidget(new ButtonControl(x, top + 190, width, 20,
+                offscreenText(), ButtonStyle.NEUTRAL, () -> {
+            allowOffscreen = !allowOffscreen;
+            refreshButtonMessages();
+        }));
+
+        addRenderableWidget(new ButtonControl(x, top + 235,
+                (width - 8) / 2, 20, "Use crosshair", ButtonStyle.NEUTRAL,
+                this::anchorFromCrosshair));
+        addRenderableWidget(new ButtonControl(x + (width - 8) / 2 + 8,
+                top + 235, (width - 8) / 2, 20, "Set 2m ahead",
+                ButtonStyle.NEUTRAL, this::anchorAhead));
+
+        int axisY = top + 263;
+        int gap = 6;
+        int axisWidth = (width - gap * 5) / 6;
+        addRenderableWidget(axisButton(x, axisY, axisWidth, "X−",
+                () -> nudge(-step(), 0, 0)));
+        addRenderableWidget(axisButton(x + (axisWidth + gap), axisY,
+                axisWidth, "X+", () -> nudge(step(), 0, 0)));
+        addRenderableWidget(axisButton(x + 2 * (axisWidth + gap), axisY,
+                axisWidth, "Y−", () -> nudge(0, -step(), 0)));
+        addRenderableWidget(axisButton(x + 3 * (axisWidth + gap), axisY,
+                axisWidth, "Y+", () -> nudge(0, step(), 0)));
+        addRenderableWidget(axisButton(x + 4 * (axisWidth + gap), axisY,
+                axisWidth, "Z−", () -> nudge(0, 0, -step())));
+        addRenderableWidget(axisButton(x + 5 * (axisWidth + gap), axisY,
+                axisWidth, "Z+", () -> nudge(0, 0, step())));
+
+        addRenderableWidget(new ButtonControl(x, top + 291,
+                (width - 8) / 2, 20, faceText(), ButtonStyle.NEUTRAL, () -> {
+            clickFace = next(clickFace, new String[]{
+                    "front", "back", "player", "north", "south",
+                    "east", "west", "up", "down"
+            });
+            refreshButtonMessages();
+        }));
+        addRenderableWidget(new ButtonControl(x + (width - 8) / 2 + 8,
+                top + 291, (width - 8) / 2, 20, rotateText(),
+                ButtonStyle.NEUTRAL, () -> {
+            rotateWith = next(rotateWith, new String[]{
+                    "none", "auto", "facing", "horizontal_facing", "axis"
+            });
+            refreshButtonMessages();
+        }));
+
+        int bottomY = top + PANEL_H - 31;
+        forgetButton = addRenderableWidget(new ButtonControl(x, bottomY,
+                76, 22, "Forget", ButtonStyle.DANGER, this::forgetRule));
+        addRenderableWidget(new ButtonControl(left + PANEL_W - 176, bottomY,
+                78, 22, "Save", ButtonStyle.PRIMARY, this::save));
+        addRenderableWidget(new ButtonControl(left + PANEL_W - 90, bottomY,
+                74, 22, "Cancel", ButtonStyle.NEUTRAL, this::onClose));
+    }
+
+    private EditBox configureField(EditBox field) {
+        field.setBordered(false);
+        field.setTextColor(WHITE);
+        field.setTextColorUneditable(MUTED);
+        field.setFormatter((value, cursor) ->
+                ScpFonts.roboto(value).getVisualOrderText());
+        return field;
+    }
+
+    private ButtonControl axisButton(int x, int y, int width,
+            String label, Runnable action) {
+        return new ButtonControl(x, y, width, 20, label,
+                ButtonStyle.NEUTRAL, action);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        actionBox.tick();
+        nameBox.tick();
+        rangeBox.tick();
+        spawnMarkerParticles();
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY,
+            float partialTick) {
+        renderBackground(graphics);
+        int left = panelLeft();
+        int top = panelTop();
+
+        graphics.fill(left, top, left + PANEL_W, top + PANEL_H, NAVY);
+        graphics.fill(left, top, left + PANEL_W, top + 31, NAVY_LIGHT);
+        graphics.fill(left, top + 30, left + PANEL_W, top + 31, ACCENT);
+        outline(graphics, left, top, PANEL_W, PANEL_H, BORDER);
+
+        graphics.drawString(font, ScpFonts.roboto("CONTEXT INTERACTION"),
+                left + 16, top + 11, WHITE, false);
+        graphics.drawString(font, ScpFonts.roboto(
+                        existing ? "Editing rule" : "Creating rule"),
+                left + 16, top + 43, MUTED, false);
+        graphics.drawString(font, ScpFonts.roboto(compact(blockId, 44)),
+                left + 16, top + 56, ACCENT_TEXT, false);
+
+        graphics.drawString(font, ScpFonts.roboto("INTERACTION"),
+                left + 16, top + 76, SECTION, false);
+        graphics.drawString(font, ScpFonts.roboto("Action"),
+                left + 16, top + 84, MUTED, false);
+        graphics.drawString(font, ScpFonts.roboto("Display name"),
+                left + 16, top + 119, MUTED, false);
+        graphics.drawString(font, ScpFonts.roboto("Range"),
+                left + 16, top + 154, MUTED, false);
+
+        drawField(graphics, actionBox);
+        drawField(graphics, nameBox);
+        drawField(graphics, rangeBox);
+
+        graphics.drawString(font, ScpFonts.roboto("ANCHOR"),
+                left + 16, top + 219, SECTION, false);
+
+        graphics.fill(left + 16, top + 319, left + PANEL_W - 16,
+                top + 342, FIELD);
+        outline(graphics, left + 16, top + 319,
+                PANEL_W - 32, 23, BORDER);
+        graphics.drawString(font, ScpFonts.roboto("Local"),
+                left + 23, top + 327, MUTED, false);
+        graphics.drawString(font, ScpFonts.roboto(
+                        "X " + fmt(anchorX) + "   Y " + fmt(anchorY)
+                                + "   Z " + fmt(anchorZ)),
+                left + 66, top + 327, ACCENT_TEXT, false);
+
+        graphics.drawString(font, ScpFonts.roboto(
+                        "Arrows X/Y · PgUp/PgDn Z · Wheel Y · Shift/Ctrl precision"),
+                left + 16, top + 348, MUTED, false);
+
+        if (!likelyRightClick) {
+            graphics.drawString(font, ScpFonts.roboto(
+                            "No right-click handler detected; saving is still allowed."),
+                    left + 16, top + 359, WARNING, false);
+        }
+
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+
+    private static void drawField(GuiGraphics graphics, EditBox field) {
+        graphics.fill(field.getX() - 3, field.getY() - 2,
+                field.getX() + field.getWidth() + 3,
+                field.getY() + field.getHeight() + 2, FIELD);
+        outline(graphics, field.getX() - 3, field.getY() - 2,
+                field.getWidth() + 6, field.getHeight() + 4, BORDER);
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (!actionBox.isFocused() && !nameBox.isFocused()
+                && !rangeBox.isFocused()) {
+            double amount = step();
+            if (keyCode == GLFW.GLFW_KEY_LEFT) {
+                nudge(-amount, 0, 0);
+                return true;
+            }
+            if (keyCode == GLFW.GLFW_KEY_RIGHT) {
+                nudge(amount, 0, 0);
+                return true;
+            }
+            if (keyCode == GLFW.GLFW_KEY_UP) {
+                nudge(0, amount, 0);
+                return true;
+            }
+            if (keyCode == GLFW.GLFW_KEY_DOWN) {
+                nudge(0, -amount, 0);
+                return true;
+            }
+            if (keyCode == GLFW.GLFW_KEY_PAGE_UP) {
+                nudge(0, 0, amount);
+                return true;
+            }
+            if (keyCode == GLFW.GLFW_KEY_PAGE_DOWN) {
+                nudge(0, 0, -amount);
+                return true;
+            }
+        }
+        return super.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
+        nudge(0, delta * step(), 0);
+        return true;
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    private void save() {
+        ModNetwork.CHANNEL.sendToServer(new ContextConfigSavePacket(
+                pos, blockId, actionBox.getValue(), nameBox.getValue(),
+                showName, parseRange(), allowE, allowRightClick,
+                allowOffscreen, useItem, clickFace, rotateWith,
+                anchorX, anchorY, anchorZ));
+        Minecraft.getInstance().setScreen(null);
+    }
+
+    private void forgetRule() {
+        if (!confirmForget) {
+            confirmForget = true;
+            if (forgetButton != null) {
+                forgetButton.setMessage(ScpFonts.roboto("Confirm"));
+            }
+            return;
+        }
+        ModNetwork.CHANNEL.sendToServer(
+                new ContextConfigDeletePacket(pos, blockId));
+        Minecraft.getInstance().setScreen(null);
+    }
+
+    private void refreshButtonMessages() {
+        for (var child : children()) {
+            if (!(child instanceof ButtonControl button)) continue;
+            String current = button.getMessage().getString();
+            if (current.startsWith("Name:")) {
+                button.setMessage(ScpFonts.roboto(nameDisplayText()));
+            } else if (current.startsWith("Input:")) {
+                button.setMessage(ScpFonts.roboto(inputText()));
+            } else if (current.startsWith("Item:")) {
+                button.setMessage(ScpFonts.roboto(itemText()));
+            } else if (current.startsWith("Off-screen:")) {
+                button.setMessage(ScpFonts.roboto(offscreenText()));
+            } else if (current.startsWith("Face:")) {
+                button.setMessage(ScpFonts.roboto(faceText()));
+            } else if (current.startsWith("Rotate:")) {
+                button.setMessage(ScpFonts.roboto(rotateText()));
+            }
+        }
+    }
+
+    private double parseRange() {
+        try {
+            return Math.max(0.25D,
+                    Double.parseDouble(rangeBox.getValue()));
+        } catch (Exception ignored) {
+            return 2.25D;
+        }
+    }
+
+    private void cycleInput() {
+        if (allowE && allowRightClick) {
+            allowRightClick = false;
+        } else if (allowE) {
+            allowE = false;
+            allowRightClick = true;
+        } else {
+            allowE = true;
+            allowRightClick = true;
+        }
+    }
+
+    private String inputText() {
+        if (allowE && allowRightClick) return "Input: Both";
+        return allowE ? "Input: E" : "Input: Right-click";
+    }
+
+    private String offscreenText() {
+        return allowOffscreen ? "Off-screen: On" : "Off-screen: Off";
+    }
+
+    private String itemText() {
+        return "card".equals(useItem) ? "Item: Card" : "Item: Hand";
+    }
+
+    private String nameDisplayText() {
+        return showName ? "Name: On" : "Name: Off";
+    }
+
+    private String faceText() {
+        return "Face: " + clickFace;
+    }
+
+    private String rotateText() {
+        return "Rotate: " + rotateWith;
+    }
+
+    private void anchorFromCrosshair() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.hitResult instanceof BlockHitResult hit
+                && hit.getType() == HitResult.Type.BLOCK) {
+            setAnchorFromWorld(hit.getLocation());
+        }
+    }
+
+    private void anchorAhead() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.player == null) return;
+        setAnchorFromWorld(minecraft.player.getEyePosition()
+                .add(minecraft.player.getViewVector(1.0F)
+                        .normalize().scale(2.0D)));
+    }
+
+    private void nudge(double x, double y, double z) {
+        setAnchorFromWorld(resolveAnchorWorld().add(x, y, z));
+    }
+
+    private void setAnchorFromWorld(Vec3 world) {
+        Vec3 centeredWorld = world.subtract(
+                Vec3.atLowerCornerOf(pos).add(0.5D, 0.5D, 0.5D));
+        Vec3 canonical = inverseRotate(centeredWorld, blockState());
+        setAnchor(canonical.x + 0.5D, canonical.y + 0.5D,
+                canonical.z + 0.5D);
+    }
+
+    private Vec3 resolveAnchorWorld() {
+        Vec3 centered = new Vec3(anchorX - 0.5D,
+                anchorY - 0.5D, anchorZ - 0.5D);
+        Vec3 rotated = rotate(centered, blockState());
+        return Vec3.atLowerCornerOf(pos).add(0.5D, 0.5D, 0.5D)
+                .add(rotated);
+    }
+
+    private void setAnchor(double x, double y, double z) {
+        anchorX = round(x);
+        anchorY = round(y);
+        anchorZ = round(z);
+    }
+
+    private double step() {
+        if (hasControlDown()) return 0.01D;
+        if (hasShiftDown()) return 0.10D;
+        return 0.05D;
+    }
+
+    private void spawnMarkerParticles() {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) return;
+        Vec3 world = resolveAnchorWorld();
+        minecraft.level.addParticle(ParticleTypes.END_ROD,
+                world.x, world.y, world.z, 0.0D, 0.01D, 0.0D);
+        minecraft.level.addParticle(ParticleTypes.ELECTRIC_SPARK,
+                world.x, world.y, world.z, 0.0D, 0.0D, 0.0D);
+    }
+
+    private BlockState blockState() {
+        Minecraft minecraft = Minecraft.getInstance();
+        return minecraft.level == null
+                ? null : minecraft.level.getBlockState(pos);
+    }
+
+    private Vec3 rotate(Vec3 local, BlockState state) {
+        Direction facing = resolveFacing(state);
+        if (facing == null || facing == Direction.NORTH) return local;
+        return switch (facing) {
+            case SOUTH -> new Vec3(-local.x, local.y, -local.z);
+            case EAST -> new Vec3(-local.z, local.y, local.x);
+            case WEST -> new Vec3(local.z, local.y, -local.x);
+            case UP, DOWN -> local;
+            default -> local;
+        };
+    }
+
+    private Vec3 inverseRotate(Vec3 local, BlockState state) {
+        Direction facing = resolveFacing(state);
+        if (facing == null || facing == Direction.NORTH) return local;
+        return switch (facing) {
+            case SOUTH -> new Vec3(-local.x, local.y, -local.z);
+            case EAST -> new Vec3(local.z, local.y, -local.x);
+            case WEST -> new Vec3(-local.z, local.y, local.x);
+            case UP, DOWN -> local;
+            default -> local;
+        };
+    }
+
+    private Direction resolveFacing(BlockState state) {
+        if (state == null || "none".equalsIgnoreCase(rotateWith)) {
+            return null;
+        }
+        if ("horizontal_facing".equalsIgnoreCase(rotateWith)) {
+            return state.hasProperty(BlockStateProperties.HORIZONTAL_FACING)
+                    ? state.getValue(BlockStateProperties.HORIZONTAL_FACING)
+                    : null;
+        }
+        if ("facing".equalsIgnoreCase(rotateWith)) {
+            return state.hasProperty(BlockStateProperties.FACING)
+                    ? state.getValue(BlockStateProperties.FACING) : null;
+        }
+        if ("axis".equalsIgnoreCase(rotateWith)) return null;
+        if (state.hasProperty(BlockStateProperties.FACING)) {
+            return state.getValue(BlockStateProperties.FACING);
+        }
+        if (state.hasProperty(BlockStateProperties.HORIZONTAL_FACING)) {
+            return state.getValue(BlockStateProperties.HORIZONTAL_FACING);
+        }
+        return null;
+    }
+
+    private String fallbackName() {
+        String path = blockId.contains(":")
+                ? blockId.substring(blockId.indexOf(':') + 1) : blockId;
+        String[] parts = path.split("_");
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) continue;
+            if (!builder.isEmpty()) builder.append(' ');
+            builder.append(Character.toUpperCase(part.charAt(0)))
+                    .append(part.substring(1));
+        }
+        return builder.isEmpty() ? blockId : builder.toString();
+    }
+
+    private int panelLeft() {
+        return Math.max(MARGIN, width - PANEL_W - MARGIN);
+    }
+
+    private int panelTop() {
+        return Math.max(MARGIN, (height - PANEL_H) / 2);
+    }
+
+    private static String next(String current, String[] values) {
+        for (int index = 0; index < values.length; index++) {
+            if (values[index].equals(current)) {
+                return values[(index + 1) % values.length];
+            }
+        }
+        return values[0];
+    }
+
+    private static String compact(String text, int max) {
+        if (text == null || text.length() <= max) {
+            return text == null ? "" : text;
+        }
+        return text.substring(0, Math.max(0, max - 3)) + "...";
+    }
+
+    private static double round(double value) {
+        return Math.round(value * 1000.0D) / 1000.0D;
+    }
+
+    private static String fmt(double value) {
+        return String.format("%.3f",
+                Mth.clamp(value, -999.0D, 999.0D));
+    }
+
+    private static void outline(GuiGraphics graphics, int x, int y,
+            int width, int height, int color) {
+        graphics.fill(x, y, x + width, y + 1, color);
+        graphics.fill(x, y + height - 1, x + width, y + height, color);
+        graphics.fill(x, y, x + 1, y + height, color);
+        graphics.fill(x + width - 1, y, x + width, y + height, color);
+    }
+
+    private enum ButtonStyle {
+        PRIMARY,
+        NEUTRAL,
+        DANGER
+    }
+
+    private final class ButtonControl extends AbstractButton {
+        private final ButtonStyle style;
+        private final Runnable action;
+
+        private ButtonControl(int x, int y, int width, int height,
+                String label, ButtonStyle style, Runnable action) {
+            super(x, y, width, height, ScpFonts.roboto(label));
+            this.style = style;
+            this.action = action;
+        }
+
+        @Override
+        public void onPress() {
+            action.run();
+        }
+
+        @Override
+        protected void updateWidgetNarration(
+                NarrationElementOutput output) {
+            defaultButtonNarrationText(output);
+        }
+
+        @Override
+        protected void renderWidget(GuiGraphics graphics, int mouseX,
+                int mouseY, float partialTick) {
+            int background = !active ? 0xFF171B25
+                    : isHoveredOrFocused() ? CONTROL_HOVER : CONTROL;
+            int edge = style == ButtonStyle.DANGER ? DANGER
+                    : style == ButtonStyle.PRIMARY ? ACCENT
+                    : isHoveredOrFocused() ? BORDER_HOVER : BORDER;
+            int text = !active ? MUTED
+                    : style == ButtonStyle.PRIMARY ? ACCENT_TEXT : WHITE;
+            graphics.fill(getX(), getY(), getX() + getWidth(),
+                    getY() + getHeight(), background);
+            outline(graphics, getX(), getY(), getWidth(),
+                    getHeight(), edge);
+            if (style != ButtonStyle.NEUTRAL) {
+                graphics.fill(getX() + 1, getY() + 1, getX() + 4,
+                        getY() + getHeight() - 1, edge);
+            }
+            graphics.drawCenteredString(font,
+                    ScpFonts.roboto(getMessage()),
+                    getX() + getWidth() / 2,
+                    getY() + (getHeight() - 8) / 2, text);
+        }
+    }
+}

--- a/src/main/java/com/bl4ues/scpinventory/client/gui/ItemRuleEditorScreen.java
+++ b/src/main/java/com/bl4ues/scpinventory/client/gui/ItemRuleEditorScreen.java
@@ -1,0 +1,630 @@
+package com.bl4ues.scpinventory.client.gui;
+
+import com.bl4ues.scpinventory.client.ScpFonts;
+import com.bl4ues.scpinventory.item.ScpItemType;
+import com.bl4ues.scpinventory.network.ItemConfigDeletePacket;
+import com.bl4ues.scpinventory.network.ItemConfigOpenPacket;
+import com.bl4ues.scpinventory.network.ItemConfigSavePacket;
+import com.bl4ues.scpinventory.network.ModNetwork;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractButton;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public final class ItemRuleEditorScreen extends Screen {
+    private static final int PANEL_W = 310;
+    private static final int PANEL_H = 228;
+    private static final int MARGIN = 10;
+
+    private static final int NAVY = 0xF000071F;
+    private static final int NAVY_LIGHT = 0xE6141E42;
+    private static final int CONTROL = 0xFF111A31;
+    private static final int CONTROL_HOVER = 0xFF192744;
+    private static final int BORDER = 0xFF46536C;
+    private static final int BORDER_HOVER = 0xFF73809A;
+    private static final int ACCENT = 0xFFC59A2A;
+    private static final int ACCENT_TEXT = 0xFFE5D49A;
+    private static final int WHITE = 0xFFF7F8FC;
+    private static final int MUTED = 0xFFA9AFBA;
+    private static final int SECTION = 0xFFD3D9E4;
+    private static final int DANGER = 0xFFD46060;
+
+    private static final ScpItemType[] TYPES =
+            Arrays.stream(ScpItemType.values())
+                    .filter(type -> type != ScpItemType.CODEX)
+                    .toArray(ScpItemType[]::new);
+
+    private final String itemId;
+    private final boolean existing;
+    private ScpItemType type;
+    private final EnumSet<EquipmentEffect> effects =
+            EnumSet.noneOf(EquipmentEffect.class);
+
+    private SingleDropdown<ScpItemType> categoryDropdown;
+    private EffectMultiSelect effectDropdown;
+    private ExpandableSelector openSelector;
+    private EditorButton forgetButton;
+    private boolean confirmForget;
+
+    public ItemRuleEditorScreen(ItemConfigOpenPacket packet) {
+        super(ScpFonts.roboto("SCP Item Configuration"));
+        this.itemId = packet.itemId();
+        this.existing = packet.existing();
+        this.type = parseType(packet.type());
+        if (packet.noStamina()) effects.add(EquipmentEffect.NO_STAMINA);
+        if (packet.protectedEyes()) {
+            effects.add(EquipmentEffect.PROTECTED_EYES);
+        }
+    }
+
+    @Override
+    protected void init() {
+        int left = panelLeft();
+        int top = panelTop();
+        int x = left + 16;
+        int width = PANEL_W - 32;
+
+        openSelector = null;
+
+        categoryDropdown = addRenderableWidget(new SingleDropdown<>(
+                x, top + 91, width, 22,
+                List.of(TYPES), type,
+                value -> ScpFonts.roboto(value.getDisplayName()),
+                value -> type = value));
+
+        effectDropdown = addRenderableWidget(new EffectMultiSelect(
+                x, top + 139, width, 22));
+
+        int bottomY = top + PANEL_H - 34;
+        forgetButton = addRenderableWidget(new EditorButton(
+                x, bottomY, 76, 22, "Forget",
+                ButtonStyle.DANGER, this::forgetRule));
+        addRenderableWidget(new EditorButton(
+                left + PANEL_W - 172, bottomY, 76, 22,
+                "Save", ButtonStyle.PRIMARY, this::save));
+        addRenderableWidget(new EditorButton(
+                left + PANEL_W - 90, bottomY, 74, 22,
+                "Cancel", ButtonStyle.NEUTRAL, this::onClose));
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (openSelector != null) {
+            if (openSelector.handleExpandedClick(mouseX, mouseY, button)) {
+                return true;
+            }
+            if (!openSelector.isMouseOver(mouseX, mouseY)) {
+                openSelector.setOpen(false);
+            }
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY,
+            double delta) {
+        if (openSelector != null
+                && openSelector.handleExpandedScroll(
+                        mouseX, mouseY, delta)) {
+            return true;
+        }
+        return super.mouseScrolled(mouseX, mouseY, delta);
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY,
+            float partialTick) {
+        renderBackground(graphics);
+        int left = panelLeft();
+        int top = panelTop();
+
+        graphics.fill(left, top, left + PANEL_W, top + PANEL_H, NAVY);
+        graphics.fill(left, top, left + PANEL_W, top + 31, NAVY_LIGHT);
+        graphics.fill(left, top + 30, left + PANEL_W, top + 31, ACCENT);
+        outline(graphics, left, top, PANEL_W, PANEL_H, BORDER);
+
+        graphics.drawString(font,
+                ScpFonts.roboto("SCP ITEM CONFIGURATION"),
+                left + 14, top + 11, WHITE, false);
+
+        ItemStack preview = getPreviewStack();
+        int iconX = left + 16;
+        int iconY = top + 44;
+        graphics.fill(iconX - 3, iconY - 3,
+                iconX + 19, iconY + 19, NAVY_LIGHT);
+        outline(graphics, iconX - 3, iconY - 3,
+                22, 22, BORDER);
+        graphics.fill(iconX - 3, iconY - 3,
+                iconX + 4, iconY - 2, ACCENT);
+        if (!preview.isEmpty()) {
+            graphics.renderItem(preview, iconX, iconY);
+        }
+
+        graphics.drawString(font,
+                ScpFonts.roboto(existing
+                        ? "Editing explicit rule"
+                        : "Creating explicit rule"),
+                left + 46, top + 44, MUTED, false);
+        graphics.drawString(font,
+                ScpFonts.roboto(compact(itemId, 42)),
+                left + 46, top + 57, WHITE, false);
+
+        graphics.drawString(font, ScpFonts.roboto("CATEGORY"),
+                left + 16, top + 78, SECTION, false);
+        graphics.drawString(font,
+                ScpFonts.roboto("EQUIPMENT EFFECTS"),
+                left + 16, top + 126, SECTION, false);
+
+        super.render(graphics, mouseX, mouseY, partialTick);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    private void save() {
+        ModNetwork.CHANNEL.sendToServer(new ItemConfigSavePacket(
+                itemId, type.name(),
+                effects.contains(EquipmentEffect.NO_STAMINA),
+                effects.contains(EquipmentEffect.PROTECTED_EYES)));
+        Minecraft.getInstance().setScreen(null);
+    }
+
+    private void forgetRule() {
+        if (!confirmForget) {
+            confirmForget = true;
+            if (forgetButton != null) {
+                forgetButton.setMessage(ScpFonts.roboto("Confirm"));
+            }
+            return;
+        }
+        ModNetwork.CHANNEL.sendToServer(
+                new ItemConfigDeletePacket(itemId));
+        Minecraft.getInstance().setScreen(null);
+    }
+
+    private ItemStack getPreviewStack() {
+        ResourceLocation id = ResourceLocation.tryParse(itemId);
+        if (id == null) return ItemStack.EMPTY;
+        return BuiltInRegistries.ITEM.getOptional(id)
+                .map(ItemStack::new).orElse(ItemStack.EMPTY);
+    }
+
+    private int panelLeft() {
+        return Math.max(MARGIN, width - PANEL_W - MARGIN);
+    }
+
+    private int panelTop() {
+        return Math.max(MARGIN, (height - PANEL_H) / 2);
+    }
+
+    private static ScpItemType parseType(String value) {
+        try {
+            ScpItemType parsed = ScpItemType.valueOf(
+                    value == null ? "MISCELLANEOUS"
+                            : value.trim().toUpperCase());
+            return parsed == ScpItemType.CODEX
+                    ? ScpItemType.MISCELLANEOUS : parsed;
+        } catch (Exception ignored) {
+            return ScpItemType.MISCELLANEOUS;
+        }
+    }
+
+    private static String compact(String text, int max) {
+        if (text == null || text.length() <= max) {
+            return text == null ? "" : text;
+        }
+        return text.substring(0, Math.max(0, max - 3)) + "...";
+    }
+
+    private static void outline(GuiGraphics graphics, int x, int y,
+            int width, int height, int color) {
+        graphics.fill(x, y, x + width, y + 1, color);
+        graphics.fill(x, y + height - 1,
+                x + width, y + height, color);
+        graphics.fill(x, y, x + 1, y + height, color);
+        graphics.fill(x + width - 1, y,
+                x + width, y + height, color);
+    }
+
+    private interface ExpandableSelector {
+        void setOpen(boolean open);
+
+        boolean handleExpandedClick(double mouseX, double mouseY,
+                int button);
+
+        boolean handleExpandedScroll(double mouseX, double mouseY,
+                double delta);
+
+        boolean isMouseOver(double mouseX, double mouseY);
+    }
+
+    private enum ButtonStyle {
+        PRIMARY,
+        NEUTRAL,
+        DANGER
+    }
+
+    private enum EquipmentEffect {
+        NO_STAMINA("No Stamina"),
+        PROTECTED_EYES("Protected Eyes");
+
+        private final String displayName;
+
+        EquipmentEffect(String displayName) {
+            this.displayName = displayName;
+        }
+
+        private String displayName() {
+            return displayName;
+        }
+    }
+
+    private class EditorButton extends AbstractButton {
+        private final ButtonStyle style;
+        private final Runnable action;
+
+        private EditorButton(int x, int y, int width, int height,
+                String label, ButtonStyle style, Runnable action) {
+            super(x, y, width, height, ScpFonts.roboto(label));
+            this.style = style;
+            this.action = action;
+        }
+
+        @Override
+        public void onPress() {
+            action.run();
+        }
+
+        @Override
+        protected void updateWidgetNarration(
+                NarrationElementOutput output) {
+            defaultButtonNarrationText(output);
+        }
+
+        @Override
+        protected void renderWidget(GuiGraphics graphics, int mouseX,
+                int mouseY, float partialTick) {
+            int background = !active ? 0xFF171B25
+                    : isHoveredOrFocused() ? CONTROL_HOVER : CONTROL;
+            int edge = style == ButtonStyle.DANGER ? DANGER
+                    : style == ButtonStyle.PRIMARY ? ACCENT
+                    : isHoveredOrFocused() ? BORDER_HOVER : BORDER;
+            int text = !active ? MUTED
+                    : style == ButtonStyle.PRIMARY ? ACCENT_TEXT : WHITE;
+            graphics.fill(getX(), getY(),
+                    getX() + getWidth(), getY() + getHeight(),
+                    background);
+            outline(graphics, getX(), getY(),
+                    getWidth(), getHeight(), edge);
+            if (style != ButtonStyle.NEUTRAL) {
+                graphics.fill(getX() + 1, getY() + 1,
+                        getX() + 4, getY() + getHeight() - 1, edge);
+            }
+            graphics.drawCenteredString(font,
+                    ScpFonts.roboto(getMessage()),
+                    getX() + getWidth() / 2,
+                    getY() + (getHeight() - 8) / 2, text);
+        }
+    }
+
+    private final class SingleDropdown<T> extends AbstractButton
+            implements ExpandableSelector {
+        private static final int ROW_HEIGHT = 22;
+        private static final int MAX_VISIBLE_ROWS = 8;
+
+        private final List<T> values;
+        private final Function<T, Component> labelFunction;
+        private final Consumer<T> onChange;
+        private T value;
+        private boolean open;
+        private int scrollOffset;
+
+        private SingleDropdown(int x, int y, int width, int height,
+                List<T> values, T initialValue,
+                Function<T, Component> labelFunction,
+                Consumer<T> onChange) {
+            super(x, y, width, height,
+                    labelFunction.apply(initialValue));
+            this.values = List.copyOf(values);
+            this.value = initialValue;
+            this.labelFunction = labelFunction;
+            this.onChange = onChange;
+        }
+
+        @Override
+        public void onPress() {
+            setOpen(!open);
+        }
+
+        @Override
+        public void setOpen(boolean shouldOpen) {
+            if (open == shouldOpen) return;
+            if (shouldOpen) {
+                if (openSelector != null && openSelector != this) {
+                    openSelector.setOpen(false);
+                }
+                openSelector = this;
+                ensureSelectionVisible();
+            } else if (openSelector == this) {
+                openSelector = null;
+            }
+            open = shouldOpen;
+        }
+
+        @Override
+        protected void updateWidgetNarration(
+                NarrationElementOutput output) {
+            defaultButtonNarrationText(output);
+        }
+
+        @Override
+        protected void renderWidget(GuiGraphics graphics,
+                int mouseX, int mouseY, float partialTick) {
+            drawSelectorFrame(graphics, this, open);
+            String label = labelFunction.apply(value).getString();
+            String clipped = font.plainSubstrByWidth(label,
+                    Math.max(1, getWidth() - 30));
+            graphics.drawString(font, ScpFonts.roboto(clipped),
+                    getX() + 8, getY() + 7, WHITE, false);
+            graphics.drawCenteredString(font,
+                    ScpFonts.roboto(open ? "▲" : "▼"),
+                    getX() + getWidth() - 12, getY() + 7, MUTED);
+            if (open) renderExpanded(graphics, mouseX, mouseY);
+        }
+
+        private void renderExpanded(GuiGraphics graphics,
+                int mouseX, int mouseY) {
+            int top = listTop();
+            int visible = visibleRows();
+            int height = visible * ROW_HEIGHT + 2;
+            graphics.pose().pushPose();
+            graphics.pose().translate(0.0F, 0.0F, 500.0F);
+            graphics.fill(getX(), top, getX() + getWidth(),
+                    top + height, 0xFF080D1C);
+            outline(graphics, getX(), top,
+                    getWidth(), height, ACCENT);
+            for (int row = 0; row < visible; row++) {
+                int index = scrollOffset + row;
+                if (index >= values.size()) break;
+                T option = values.get(index);
+                int rowY = top + 1 + row * ROW_HEIGHT;
+                boolean hovered = mouseX >= getX()
+                        && mouseX < getX() + getWidth()
+                        && mouseY >= rowY
+                        && mouseY < rowY + ROW_HEIGHT;
+                boolean selected = Objects.equals(option, value);
+                graphics.fill(getX() + 1, rowY,
+                        getX() + getWidth() - 1,
+                        rowY + ROW_HEIGHT,
+                        selected ? 0xFF4B3F27
+                                : hovered ? CONTROL_HOVER : CONTROL);
+                graphics.drawString(font,
+                        labelFunction.apply(option),
+                        getX() + 8, rowY + 7,
+                        selected ? ACCENT_TEXT : WHITE, false);
+            }
+            graphics.pose().popPose();
+        }
+
+        @Override
+        public boolean handleExpandedClick(double mouseX,
+                double mouseY, int button) {
+            if (!open || button != 0) return false;
+            int top = listTop();
+            int visible = visibleRows();
+            if (mouseX >= getX() && mouseX < getX() + getWidth()
+                    && mouseY >= top
+                    && mouseY < top + visible * ROW_HEIGHT + 2) {
+                int row = (int) ((mouseY - top - 1) / ROW_HEIGHT);
+                int index = scrollOffset + row;
+                if (row >= 0 && row < visible
+                        && index < values.size()) {
+                    value = values.get(index);
+                    setMessage(labelFunction.apply(value));
+                    onChange.accept(value);
+                }
+                setOpen(false);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean handleExpandedScroll(double mouseX,
+                double mouseY, double delta) {
+            if (!open || values.size() <= visibleRows()) return false;
+            int top = listTop();
+            int height = visibleRows() * ROW_HEIGHT + 2;
+            if (mouseX < getX()
+                    || mouseX >= getX() + getWidth()
+                    || mouseY < top || mouseY >= top + height) {
+                return false;
+            }
+            scrollOffset = Math.max(0, Math.min(maxScroll(),
+                    scrollOffset + (delta > 0.0D ? -1 : 1)));
+            return true;
+        }
+
+        private int visibleRows() {
+            return Math.min(MAX_VISIBLE_ROWS, values.size());
+        }
+
+        private int maxScroll() {
+            return Math.max(0, values.size() - visibleRows());
+        }
+
+        private int listTop() {
+            int height = visibleRows() * ROW_HEIGHT + 2;
+            int below = getY() + getHeight() + 2;
+            return below + height <= ItemRuleEditorScreen.this.height - 6
+                    ? below : getY() - height - 2;
+        }
+
+        private void ensureSelectionVisible() {
+            int selected = Math.max(0, values.indexOf(value));
+            if (selected < scrollOffset) scrollOffset = selected;
+            if (selected >= scrollOffset + visibleRows()) {
+                scrollOffset = selected - visibleRows() + 1;
+            }
+            scrollOffset = Math.max(0,
+                    Math.min(maxScroll(), scrollOffset));
+        }
+    }
+
+    private final class EffectMultiSelect extends AbstractButton
+            implements ExpandableSelector {
+        private static final int ROW_HEIGHT = 24;
+        private boolean open;
+
+        private EffectMultiSelect(int x, int y, int width, int height) {
+            super(x, y, width, height,
+                    ScpFonts.roboto(effectSummary()));
+        }
+
+        @Override
+        public void onPress() {
+            setOpen(!open);
+        }
+
+        @Override
+        public void setOpen(boolean shouldOpen) {
+            if (open == shouldOpen) return;
+            if (shouldOpen) {
+                if (openSelector != null && openSelector != this) {
+                    openSelector.setOpen(false);
+                }
+                openSelector = this;
+            } else if (openSelector == this) {
+                openSelector = null;
+            }
+            open = shouldOpen;
+        }
+
+        @Override
+        protected void updateWidgetNarration(
+                NarrationElementOutput output) {
+            defaultButtonNarrationText(output);
+        }
+
+        @Override
+        protected void renderWidget(GuiGraphics graphics,
+                int mouseX, int mouseY, float partialTick) {
+            drawSelectorFrame(graphics, this, open);
+            String clipped = font.plainSubstrByWidth(
+                    effectSummary(), Math.max(1, getWidth() - 30));
+            graphics.drawString(font, ScpFonts.roboto(clipped),
+                    getX() + 8, getY() + 7, WHITE, false);
+            graphics.drawCenteredString(font,
+                    ScpFonts.roboto(open ? "▲" : "▼"),
+                    getX() + getWidth() - 12, getY() + 7, MUTED);
+            if (open) renderExpanded(graphics, mouseX, mouseY);
+        }
+
+        private void renderExpanded(GuiGraphics graphics,
+                int mouseX, int mouseY) {
+            int top = listTop();
+            int height = EquipmentEffect.values().length
+                    * ROW_HEIGHT + 2;
+            graphics.pose().pushPose();
+            graphics.pose().translate(0.0F, 0.0F, 500.0F);
+            graphics.fill(getX(), top,
+                    getX() + getWidth(), top + height, 0xFF080D1C);
+            outline(graphics, getX(), top,
+                    getWidth(), height, ACCENT);
+            EquipmentEffect[] options = EquipmentEffect.values();
+            for (int index = 0; index < options.length; index++) {
+                EquipmentEffect option = options[index];
+                int rowY = top + 1 + index * ROW_HEIGHT;
+                boolean hovered = mouseX >= getX()
+                        && mouseX < getX() + getWidth()
+                        && mouseY >= rowY
+                        && mouseY < rowY + ROW_HEIGHT;
+                boolean selected = effects.contains(option);
+                graphics.fill(getX() + 1, rowY,
+                        getX() + getWidth() - 1,
+                        rowY + ROW_HEIGHT,
+                        hovered ? CONTROL_HOVER : CONTROL);
+                graphics.drawString(font,
+                        ScpFonts.roboto(selected ? "✓" : "□"),
+                        getX() + 8, rowY + 8,
+                        selected ? ACCENT_TEXT : MUTED, false);
+                graphics.drawString(font,
+                        ScpFonts.roboto(option.displayName()),
+                        getX() + 27, rowY + 8,
+                        selected ? ACCENT_TEXT : WHITE, false);
+            }
+            graphics.pose().popPose();
+        }
+
+        @Override
+        public boolean handleExpandedClick(double mouseX,
+                double mouseY, int button) {
+            if (!open || button != 0) return false;
+            int top = listTop();
+            int height = EquipmentEffect.values().length
+                    * ROW_HEIGHT + 2;
+            if (mouseX >= getX() && mouseX < getX() + getWidth()
+                    && mouseY >= top && mouseY < top + height) {
+                int row = (int) ((mouseY - top - 1) / ROW_HEIGHT);
+                EquipmentEffect[] options = EquipmentEffect.values();
+                if (row >= 0 && row < options.length) {
+                    EquipmentEffect option = options[row];
+                    if (!effects.remove(option)) effects.add(option);
+                    setMessage(ScpFonts.roboto(effectSummary()));
+                }
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean handleExpandedScroll(double mouseX,
+                double mouseY, double delta) {
+            return false;
+        }
+
+        private int listTop() {
+            int height = EquipmentEffect.values().length
+                    * ROW_HEIGHT + 2;
+            int below = getY() + getHeight() + 2;
+            return below + height <= ItemRuleEditorScreen.this.height - 6
+                    ? below : getY() - height - 2;
+        }
+    }
+
+    private String effectSummary() {
+        if (effects.isEmpty()) return "No equipment effects";
+        if (effects.size() == 1) {
+            return effects.iterator().next().displayName();
+        }
+        return "No Stamina, Protected Eyes";
+    }
+
+    private void drawSelectorFrame(GuiGraphics graphics,
+            AbstractButton button, boolean open) {
+        int background = button.isHoveredOrFocused() || open
+                ? CONTROL_HOVER : CONTROL;
+        int edge = open ? ACCENT
+                : button.isHoveredOrFocused()
+                        ? BORDER_HOVER : BORDER;
+        graphics.fill(button.getX(), button.getY(),
+                button.getX() + button.getWidth(),
+                button.getY() + button.getHeight(), background);
+        outline(graphics, button.getX(), button.getY(),
+                button.getWidth(), button.getHeight(), edge);
+    }
+}


### PR DESCRIPTION
Replace the cluttered context anchor editor with a self-contained Roboto UI, remove duplicated explanatory text, keep only operational guidance and the right-click warning, and preserve all existing anchor controls. Replace the item editor category cycle with a single-select dropdown and equipment effect toggles with a multi-select dropdown. Route both client handlers to the new screens and validate with the normal clean Gradle build.