### PR TITLE
Fine-tune structured document rendering

### DIFF
--- a/src/main/java/net/mcreator/scpadditions/client/DocumentEditorScreen.java
+++ b/src/main/java/net/mcreator/scpadditions/client/DocumentEditorScreen.java
@@ -165,8 +165,13 @@ public final class DocumentEditorScreen extends Screen {
                 Component.literal("Cancel"),
                 ButtonStyle.NEUTRAL, this::onClose));
 
-        if (templateMenu) addTemplateChoices(innerLeft,
-                templateY + 24, innerWidth - 118);
+        if (templateMenu) {
+            int menuY = templateY + 24;
+            int menuWidth = innerWidth - 118;
+            suppressFieldsBehindMenu(innerLeft, menuY,
+                    menuWidth, templateMenuHeight());
+            addTemplateChoices(innerLeft, menuY, menuWidth);
+        }
     }
 
     private void calculateLayout() {
@@ -235,7 +240,7 @@ public final class DocumentEditorScreen extends Screen {
     private EditBox field(int x, int y, int width,
                           String hint, String value) {
         fieldFrames.add(new FieldFrame(x, y, Math.max(40, width), 22));
-        EditBox box = new EditBox(font, x + 5, y + 2,
+        EditBox box = new EditBox(font, x + 5, y + 4,
                 Math.max(30, width - 10), 18, Component.literal(hint));
         box.setBordered(false);
         box.setTextColor(TEXT_PRIMARY);
@@ -412,6 +417,53 @@ public final class DocumentEditorScreen extends Screen {
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
         body.rememberFocus();
+        if (templateMenu) {
+            if (button != 0) return true;
+
+            int innerLeft = panelX + 18;
+            int innerWidth = panelW - 36;
+            int menuX = innerLeft;
+            int menuY = templateY + 24;
+            int menuWidth = innerWidth - 118;
+            int menuHeight = templateMenuHeight();
+
+            if (inside(mouseX, mouseY,
+                    menuX, menuY, menuWidth, menuHeight)) {
+                int relativeY = (int) mouseY - menuY;
+                int index = relativeY / 23;
+                int withinRow = relativeY % 23;
+                DocumentData.Template[] choices =
+                        DocumentData.Template.values();
+                if (index >= 0 && index < choices.length
+                        && withinRow < 22) {
+                    captureDraft();
+                    template = choices[index];
+                    templateMenu = false;
+                    rebuildEditor(false);
+                }
+                return true;
+            }
+
+            if (inside(mouseX, mouseY,
+                    innerLeft, templateY,
+                    innerWidth - 118, 22)) {
+                toggleTemplateMenu();
+                return true;
+            }
+
+            if (inside(mouseX, mouseY,
+                    innerLeft + innerWidth - 112,
+                    templateY, 112, 22)) {
+                templateMenu = false;
+                applyTemplate();
+                return true;
+            }
+
+            captureDraft();
+            templateMenu = false;
+            rebuildEditor(false);
+            return true;
+        }
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
@@ -464,7 +516,7 @@ public final class DocumentEditorScreen extends Screen {
 
         for (Map.Entry<EditBox, Integer> entry : body.visible().entrySet()) {
             EditBox box = entry.getKey();
-            int rowY = box.getY() - 2;
+            int rowY = box.getY() - 4;
             graphics.fill(bodyX, rowY,
                     bodyX + bodyW, rowY + 22, ROW_BACKGROUND);
             outline(graphics, bodyX, rowY, bodyW, 22, FIELD_EDGE);
@@ -472,7 +524,7 @@ public final class DocumentEditorScreen extends Screen {
                     bodyX + 30, rowY + 19, 0xFF30383E);
             graphics.drawCenteredString(font,
                     ScpFonts.roboto(Integer.toString(entry.getValue() + 1)),
-                    bodyX + 14, rowY + 7, TEXT_MUTED);
+                    bodyX + 14, rowY + 8, TEXT_MUTED);
         }
 
         graphics.drawString(font, ScpFonts.roboto(notice),
@@ -514,6 +566,54 @@ public final class DocumentEditorScreen extends Screen {
         body.detach();
         clearWidgets();
         init();
+    }
+
+    private int templateMenuHeight() {
+        return Math.max(0,
+                DocumentData.Template.values().length * 23 - 1);
+    }
+
+    private void suppressFieldsBehindMenu(int x, int y,
+                                          int width, int height) {
+        hideIfIntersects(title, x, y, width, height);
+        hideIfIntersects(category, x, y, width, height);
+        hideIfIntersects(caption, x, y, width, height);
+        for (EditBox box : labels) {
+            hideIfIntersects(box, x, y, width, height);
+        }
+        for (EditBox box : values) {
+            hideIfIntersects(box, x, y, width, height);
+        }
+        for (EditBox box : body.visible().keySet()) {
+            hideIfIntersects(box, x, y, width, height);
+        }
+    }
+
+    private static void hideIfIntersects(EditBox box,
+                                         int x, int y,
+                                         int width, int height) {
+        if (box == null || !intersects(box.getX(), box.getY(),
+                box.getWidth(), box.getHeight(),
+                x, y, width, height)) {
+            return;
+        }
+        box.visible = false;
+        box.active = false;
+    }
+
+    private static boolean inside(double mouseX, double mouseY,
+                                  int x, int y,
+                                  int width, int height) {
+        return mouseX >= x && mouseX < x + width
+                && mouseY >= y && mouseY < y + height;
+    }
+
+    private static boolean intersects(int x1, int y1,
+                                      int width1, int height1,
+                                      int x2, int y2,
+                                      int width2, int height2) {
+        return x1 < x2 + width2 && x1 + width1 > x2
+                && y1 < y2 + height2 && y1 + height1 > y2;
     }
 
     private static void drawField(GuiGraphics graphics, int x, int y,

--- a/src/main/java/net/mcreator/scpadditions/client/DocumentRenderer.java
+++ b/src/main/java/net/mcreator/scpadditions/client/DocumentRenderer.java
@@ -10,7 +10,7 @@ import net.mcreator.scpadditions.document.DocumentData;
 
 /** Renders the official document template in previews and the Codex. */
 public final class DocumentRenderer {
-    /** Native dimensions of both supplied document assets. */
+    /** Native layout dimensions used by both supplied document assets. */
     public static final int PAGE_WIDTH = 1497;
     public static final int PAGE_HEIGHT = 2246;
 
@@ -21,16 +21,11 @@ public final class DocumentRenderer {
             new ResourceLocation("scp_additions",
                     "textures/gui/picture.png");
 
-    /*
-     * These positions use the coordinates supplied for the original assets.
-     * The old renderer incorrectly converted them to a smaller virtual canvas,
-     * which displaced every element despite preserving the page aspect ratio.
-     */
     private static final int HEADER_LEFT_X = 470;
     private static final int HEADER_RIGHT_X = 1026;
-    private static final int HEADER_ROW_1_Y = 106;
-    private static final int HEADER_ROW_2_Y = 218;
-    private static final int HEADER_ROW_3_Y = 330;
+    private static final int HEADER_ROW_1_Y = 108;
+    private static final int HEADER_ROW_2_Y = 220;
+    private static final int HEADER_ROW_3_Y = 332;
 
     private static final int BODY_X = 72;
     private static final int BODY_Y = 529;
@@ -135,32 +130,11 @@ public final class DocumentRenderer {
         int frameWidth = PHOTO_RIGHT - PHOTO_X;
         int frameHeight = PHOTO_BOTTOM - PHOTO_Y;
 
-        /*
-         * Draw the supplied overlay first. Some image editors exported its
-         * nominal window with opaque pixels, so placing it after the photo can
-         * hide the photograph completely. The photograph is then drawn inside
-         * the frame and the thin border/caption strips are restored on top.
-         */
-        setTextureFiltering(PICTURE_FRAME, true);
-        graphics.blit(PICTURE_FRAME, 0, 0,
-                PAGE_WIDTH, PAGE_HEIGHT,
-                0.0F, 0.0F,
-                PAGE_WIDTH, PAGE_HEIGHT,
-                PAGE_WIDTH, PAGE_HEIGHT);
-
-        final int border = 6;
-        int photoX = PHOTO_X + border;
-        int photoY = PHOTO_Y + border;
-        int photoWidth = Math.max(1, frameWidth - border * 2);
-        int photoHeight = Math.max(1, frameHeight - border * 2);
-
         if (photo != null) {
             int sourceWidth = state.photoWidth();
             int sourceHeight = state.photoHeight();
-            float targetAspect =
-                    photoWidth / (float) photoHeight;
-            float sourceAspect =
-                    sourceWidth / (float) sourceHeight;
+            float targetAspect = frameWidth / (float) frameHeight;
+            float sourceAspect = sourceWidth / (float) sourceHeight;
 
             int cropWidth = sourceWidth;
             int cropHeight = sourceHeight;
@@ -169,75 +143,65 @@ public final class DocumentRenderer {
 
             if (sourceAspect > targetAspect) {
                 cropWidth = Math.max(1,
-                        Math.round(sourceHeight * targetAspect));
+                        (int) Math.ceil(sourceHeight * targetAspect));
                 u = Math.max(0,
                         (sourceWidth - cropWidth) / 2);
             } else if (sourceAspect < targetAspect) {
                 cropHeight = Math.max(1,
-                        Math.round(sourceWidth / targetAspect));
+                        (int) Math.ceil(sourceWidth / targetAspect));
                 v = Math.max(0,
                         (sourceHeight - cropHeight) / 2);
             }
 
             setTextureFiltering(photo, true);
             graphics.blit(photo,
-                    photoX, photoY,
-                    photoWidth, photoHeight,
+                    PHOTO_X, PHOTO_Y,
+                    frameWidth, frameHeight,
                     (float) u, (float) v,
                     cropWidth, cropHeight,
                     sourceWidth, sourceHeight);
             setTextureFiltering(photo, false);
         }
 
-        // Restore only the frame edges and caption strip above the photo.
-        blitFrameRegion(graphics, PHOTO_X, PHOTO_Y,
-                frameWidth, border);
-        blitFrameRegion(graphics, PHOTO_X,
-                PHOTO_BOTTOM - border,
-                frameWidth, border);
-        blitFrameRegion(graphics, PHOTO_X, PHOTO_Y,
-                border, frameHeight);
-        blitFrameRegion(graphics,
-                PHOTO_RIGHT - border, PHOTO_Y,
-                border, frameHeight);
-        blitFrameRegion(graphics, PHOTO_X, CAPTION_TOP,
-                frameWidth, CAPTION_BOTTOM - CAPTION_TOP);
+        /*
+         * The supplied frame contains a semi-transparent crumpled-paper layer
+         * inside its photograph window. Drawing the complete asset after the
+         * photograph preserves that texture while its opaque edges and caption
+         * strip cover the photograph cleanly, without exposed empty margins.
+         */
+        setTextureFiltering(PICTURE_FRAME, true);
+        graphics.blit(PICTURE_FRAME, 0, 0,
+                PAGE_WIDTH, PAGE_HEIGHT,
+                0.0F, 0.0F,
+                PAGE_WIDTH, PAGE_HEIGHT,
+                PAGE_WIDTH, PAGE_HEIGHT);
         setTextureFiltering(PICTURE_FRAME, false);
 
         if (!state.caption().isBlank()) {
             Component caption = ScpFonts.roboto(state.caption())
                     .withStyle(style -> style.withItalic(true));
-            float captionScale = 2.55F;
+            float captionScale = 3.15F;
             int width = Math.round(
                     Minecraft.getInstance().font.width(caption)
                             * captionScale);
-            int maxWidth = frameWidth - 20;
+            int maxWidth = frameWidth - 28;
             float fittedScale = captionScale;
             if (width > maxWidth && width > 0) {
                 fittedScale *= maxWidth / (float) width;
                 width = maxWidth;
             }
 
-            int x = PHOTO_X
-                    + Math.max(10, (frameWidth - width) / 2);
+            int x = PHOTO_X + (frameWidth - width) / 2;
             int textHeight = Math.round(
                     Minecraft.getInstance().font.lineHeight
                             * fittedScale);
-            int y = CAPTION_TOP + Math.max(4,
-                    (CAPTION_BOTTOM - CAPTION_TOP
-                            - textHeight) / 2);
+            int y = CAPTION_TOP
+                    + (CAPTION_BOTTOM - CAPTION_TOP - textHeight) / 2
+                    + 1;
             drawScaledText(graphics, caption,
                     x, y, TEXT_COLOR,
                     fittedScale, false);
         }
-    }
-
-    private static void blitFrameRegion(GuiGraphics graphics,
-                                        int x, int y,
-                                        int width, int height) {
-        graphics.blit(PICTURE_FRAME, x, y, width, height,
-                (float) x, (float) y, width, height,
-                PAGE_WIDTH, PAGE_HEIGHT);
     }
 
     private static void drawScaledText(GuiGraphics graphics,

--- a/src/main/java/net/mcreator/scpadditions/client/LineMarkdownEditor.java
+++ b/src/main/java/net/mcreator/scpadditions/client/LineMarkdownEditor.java
@@ -56,7 +56,7 @@ final class LineMarkdownEditor {
             if (index >= lines.size()) break;
 
             EditBox box = new EditBox(font,
-                    x + 34, y + row * ROW_HEIGHT + 2,
+                    x + 34, y + row * ROW_HEIGHT + 4,
                     Math.max(40, width - 40), 18,
                     Component.literal("Body line " + (index + 1)));
             box.setBordered(false);

--- a/src/main/java/net/mcreator/scpadditions/client/MarkdownTextRenderer.java
+++ b/src/main/java/net/mcreator/scpadditions/client/MarkdownTextRenderer.java
@@ -47,9 +47,13 @@ public final class MarkdownTextRenderer {
                 : markdown.replace("\r\n", "\n").replace('\r', '\n');
         String[] paragraphs = normalized.split("\n", -1);
         int y = startY;
-        int lineCount = 0;
+        int paragraphGap = Math.max(3,
+                Math.round(lineHeight * 0.28F));
 
-        for (String paragraph : paragraphs) {
+        for (int paragraphIndex = 0;
+             paragraphIndex < paragraphs.length;
+             paragraphIndex++) {
+            String paragraph = paragraphs[paragraphIndex];
             int available = Math.max(1, widthAtY.applyAsInt(y));
 
             if (paragraph.trim().equals("---")) {
@@ -62,15 +66,20 @@ public final class MarkdownTextRenderer {
                             0xAA202020);
                 }
                 y += lineHeight;
-                lineCount++;
-                if (draw && y > maxY) break;
+                if (paragraphIndex + 1 < paragraphs.length) {
+                    y += paragraphGap;
+                }
+                if (draw && y > maxY) {
+                    return heightInLines(startY, y, lineHeight);
+                }
                 continue;
             }
 
             if (paragraph.isEmpty()) {
                 y += lineHeight;
-                lineCount++;
-                if (draw && y > maxY) break;
+                if (draw && y > maxY) {
+                    return heightInLines(startY, y, lineHeight);
+                }
                 continue;
             }
 
@@ -121,14 +130,28 @@ public final class MarkdownTextRenderer {
                 }
 
                 y += lineHeight;
-                lineCount++;
                 if (draw && y > maxY) {
-                    return Math.max(1, lineCount);
+                    return heightInLines(startY, y, lineHeight);
+                }
+            }
+
+            if (paragraphIndex + 1 < paragraphs.length) {
+                y += paragraphGap;
+                if (draw && y > maxY) {
+                    return heightInLines(startY, y, lineHeight);
                 }
             }
         }
 
-        return Math.max(1, lineCount);
+        return heightInLines(startY, y, lineHeight);
+    }
+
+    private static int heightInLines(int startY, int endY,
+                                     int lineHeight) {
+        int height = Math.max(lineHeight, endY - startY);
+        return Math.max(1,
+                (height + Math.max(1, lineHeight) - 1)
+                        / Math.max(1, lineHeight));
     }
 
     private static void renderLine(GuiGraphics graphics, Font font,
@@ -161,8 +184,11 @@ public final class MarkdownTextRenderer {
 
             Word word = placed.word();
             if (word.redacted()) {
-                int barHeight = Math.max(3, Math.round(
-                        font.lineHeight * textScale * 0.70F));
+                int desiredHeight = Math.max(4, Math.round(
+                        font.lineHeight * textScale * 0.92F));
+                int barHeight = Math.min(
+                        Math.max(4, lineHeight - 2),
+                        desiredHeight);
                 int barY = y + Math.max(0,
                         (lineHeight - barHeight) / 2);
                 graphics.fill(x, barY,


### PR DESCRIPTION
Refines the structured document editor after the latest in-game review:

- lowers header baselines slightly;
- makes photograph cropping fully cover the frame;
- restores the complete translucent paper overlay above photographs;
- enlarges and centers photograph captions;
- adds paragraph spacing for Markdown line breaks;
- lowers text inside editor fields;
- increases redaction bar height;
- prevents fields behind the template dropdown from rendering or capturing clicks.

The branch is only being used to run the build before squashing the result into master.